### PR TITLE
 Make wobj.py Python3 Compatible #12 

### DIFF
--- a/scripts/visualisation/PyMOL/wobj_python3.py
+++ b/scripts/visualisation/PyMOL/wobj_python3.py
@@ -1,0 +1,424 @@
+# CHAP - The Channel Annotation Package
+#
+# Copyright (c) 2016 - 2018 Gianni Klesse, Shanlin Rao, Mark S. P. Sansom, and
+# Stephen J. Tucker
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+from pymol import cmd
+from pymol.cgo import *
+
+
+class WavefrontMtlImporter:
+    """ Reads material specifications from Wavefront MTL files.
+
+    Currently only supports reading ambient (Ka), diffuse (Kd), and specular
+    (Ks) colours from each material definition introduces with newmtl.
+    """
+
+    # dictionary of materials:
+    __materials = dict()
+
+    # most recently read material name:
+    __crnt_material = ""
+
+
+    def read(self, filename):
+
+        # read data from MTL file:
+        with open(filename, "r") as f:
+
+            # file is parsed line by line:
+            for line in f: self.__parse_line(line)
+
+        # return materials dictionary:
+        return self.__materials
+
+
+    def __parse_line(self, line):
+        """ Parses one line from an MTL file.
+
+        Currently only supports newmtl, Ka, Kd, and Ks records. Depending on
+        which of these records in encountered, the corresponding parse function
+        is called to further process the line. If an unknown record is
+        encountered, this method will throw an exception.
+
+        Args:
+            line: a string read from an MTL file
+        """
+
+        # split line at space:
+        split_line = line.split(" ")
+
+        # what type of record does the lien contain?
+        if split_line[0] == "newmtl": self.__parse_newmtl_line(split_line)
+        elif split_line[0] == "Ka": self.__parse_ka_line(split_line)
+        elif split_line[0] == "Kd": self.__parse_kd_line(split_line)
+        elif split_line[0] == "Ks": self.__parse_ks_line(split_line)
+        else: raise Exception("Encountered unknown record type: " + line)
+
+
+    def __parse_newmtl_line(self, split_line):
+        """ Parses a newmtl record read from a MTL file.
+
+        This will create a dictionary for the new material and also change the
+        current matrial member variable accordingly.
+
+        Args:
+            split_line: list of strings, MTL line split at spaces
+        """
+
+        # change current material:
+        self.__crnt_material = split_line[1].rstrip()
+
+        # add current material to dictionary:
+        self.__materials[self.__crnt_material] = dict()
+
+
+    def __parse_ka_line(self, split_line):
+        """ Parses an ambient colour record read from a MTL file.
+
+        This will add an ambient colour definition to the current material.
+
+        Args:
+            split_line: list of strings, MTL line split at spaces
+        """
+
+        # add ambient colour value to materials dictionary:
+        self.__materials[self.__crnt_material]["Ka"] = list(map(float, split_line[1:4]))
+
+
+    def __parse_kd_line(self, split_line):
+        """ Parses a diffuse colour record read from a MTL file.
+
+        This will add an diffuse colour definition to the current material.
+
+        Args:
+            split_line: list of strings, MTL line split at spaces
+        """
+
+        # add ambient colour value to materials dictionary:
+        self.__materials[self.__crnt_material]["Kd"] = list(map(float, split_line[1:4]))
+
+
+    def __parse_ks_line(self, split_line):
+        """ Parses a specular colour record read from a MTL file.
+
+        This will add an specular colour definition to the current material.
+
+        Args:
+            split_line: list of strings, MTL line split at spaces
+        """
+
+        # add ambient colour value to materials dictionary:
+        self.__materials[self.__crnt_material]["Ks"] = list(map(float, split_line[1:4]))
+
+
+
+class WavefrontObjImporter:
+    """ Reads scene data from Wavefront OBJ files.
+
+    Currently supports reading of vertices and vertex normals, but not texture
+    vertices. Expects every face to have a vertex and vertex normal index
+    specification.
+    """
+
+    # dictionary of faces in groups:
+    __groups = dict()
+
+    # dictionary of materials read from MTL file:
+    __materials = dict()
+
+    # lists for vertices and vertex normals:
+    __vertices = []
+    __normals = []
+
+    # keep track of object, group, and material associated with a face:
+    __crnt_object = ""
+    __crnt_group = ""
+    __crnt_material = ""
+
+
+    def read(self, filename):
+        """ Reads data from a Wavefront OBJ file.
+
+        Args:
+            filename: name of the OBJ file to read
+
+        Returns:
+            dict: a dictionary of Compiled Graphics Objects
+        """
+
+        # read data from OBJ file:
+        with open(filename, "r") as f:
+
+            # file is parsed line by line:
+            for line in f: self.__parse_line(line)
+
+        # create a dictionary for the CGO objects to be returned:
+        cgo = dict()
+
+        # loop over groups:
+        for key in self.__groups:
+
+            # add faces to CGO object:
+            cgo[key] = self.__create_cgo_object(key)
+
+        # return dictionary of cgo objects:
+        return cgo
+
+
+    def __parse_line(self, line):
+        """ Parses a single line read from an OBJ file.
+
+        This will split the line string at spaces and check which type of
+        record the line contains. It will then call the appropriate line
+        parsing function.
+
+        Args:
+            line: string representing line from OBJ file
+        """
+
+        # split string at space:
+        split_line = line.split(" ")
+
+        # determine type of record:
+        if split_line[0] == "#": return           # ignore comments
+        elif split_line[0] == "mtllib": self.__parse_mtllib_line(split_line)
+        elif split_line[0] == "o": self.__parse_o_line(split_line)
+        elif split_line[0] == "g": self.__parse_g_line(split_line)
+        elif split_line[0] == "usemtl": self.__parse_usemtl_line(split_line)
+        elif split_line[0] == "v": self.__parse_v_line(split_line)
+        elif split_line[0] == "vn": self.__parse_vn_line(split_line)
+        elif split_line[0] == "f": self.__parse_f_line(split_line)
+        elif split_line[0] == "\n": return        # ignore empty lines
+        else: raise Exception("Encountered unknorn record type: " + line)
+
+
+    def __parse_mtllib_line(self, split_line):
+        """ Parses a mtllib record read from an OBJ file.
+
+        This will use the WavefrontMtlImporter class to parse the MTL file
+        specified in the record. The resulting materials are then added to an
+        internal dictionary.
+
+        Args:
+            split_line: list of strings created by splitting line at spaces
+        """
+
+        mtl_importer = WavefrontMtlImporter()
+        self.__materials = mtl_importer.read(split_line[1].rstrip())
+
+
+    def __parse_o_line(self, split_line):
+        """ Parses an o record read from an OBJ file.
+
+        This will simply change the current object variable.
+
+        Args:
+            split_line: list of strings created by splitting line at spaces
+        """
+
+        # new current object:
+        __crnt_object = split_line[1]
+
+
+    def __parse_usemtl_line(self, split_line):
+        """ Parses an usemtl record read from an OBJ file.
+
+        This will change the current material to the value contained in the
+        given record.
+
+        Args:
+            split_line: list of strings created by splitting line at spaces
+        """
+
+        # new current material:
+        self.__crnt_material = split_line[1].rstrip()
+
+
+    def __parse_g_line(self, split_line):
+        """ Parses a g record read from an OBJ file.
+
+        This changes the current group name and also creates a dictionary
+        entry for this group name. Inside this dictionary, an empty list of
+        faces is created.
+
+        Args:
+            split_line: list of strings created by splitting line at spaces
+        """
+
+        # new current group:
+        self.__crnt_group = split_line[1].rstrip()
+
+        # add group to group dictionary:
+        self.__groups[self.__crnt_group] = dict()
+        self.__groups[self.__crnt_group]["faces"] = []
+
+
+    def __parse_v_line(self, split_line):
+        """ Parses a v record read from an OBJ file.
+
+        This adds a new 3-vector of floats to the internal list of vertices.
+
+        Args:
+            split_line: list of strings created by splitting line at spaces
+        """
+
+        # append vertex 3-vector to list of vertices:
+        self.__vertices.append(list(map(float, split_line[1:4])))
+
+
+    def __parse_vn_line(self, split_line):
+        """ Parses a vn record read from an OBJ file.
+
+        This adds a new 3-vector of floats to the internal list of vertex
+        normals.
+
+        Args:
+            split_line: list of strings created by splitting line at spaces
+        """
+
+        # append vertex normal 3-vector to list of vertices:
+        self.__normals.append(list(map(float, split_line[1:4])))
+
+
+    def __parse_f_line(self, split_line):
+        """ Parses a f record read from an OBJ file.
+
+        This adds a new entry to the list of faces for the current group. A
+        face entry consists of two 3-vectors of vertex indices and vertex
+        normal indices as well as the name of the current material.
+
+        Args:
+            split_line: list of strings created by splitting line at spaces
+        """
+
+        # split at slash to separate out vertex, texture and normal index:
+        all_indices = list(map(lambda x: x.split("/"), split_line[1:4]))
+
+        # create a face with material and index into vertex and normal lists:
+        face = dict()
+        face["material"] = self.__crnt_material
+        face["vert_idx"] = list(map(int, list(map(lambda x: x[0], all_indices))) )
+        face["norm_idx"] = list(map(int, list(map(lambda x: x[2], all_indices))) )
+
+        # append face to list of faces for the current group:
+        self.__groups[self.__crnt_group]["faces"].append(face)
+
+
+    def __create_cgo_object(self, groupname):
+        """ Creates a Compiled Graphics Object from the fully parsed OBJ file.
+
+        This function is called after all records have been read from an OBJ
+        file and associated MTL file. It goes through the list of all faces
+        for the given group and creates a CGO TRIANGLE entry for each.
+
+        Args:
+            groupname: string, must be a key in the groups dictionary
+
+        Returns:
+            CGO: a Compiled Graphics Object compatible with PyMOL
+        """
+
+        # create a CGO object:
+        cgo_object = [ BEGIN, TRIANGLES ]
+
+        # loop over faces in group:
+        for face in self.__groups[groupname]["faces"]:
+
+            # obtain vertices (note index shift wrt OBJ file):
+            vertex_a = self.__vertices[face["vert_idx"][0] - 1]
+            vertex_b = self.__vertices[face["vert_idx"][1] - 1]
+            vertex_c = self.__vertices[face["vert_idx"][2] - 1]
+
+            # obtain normals (note index shift wrt OBJ file):
+            normal_a = self.__normals[face["norm_idx"][0] - 1]
+            normal_b = self.__normals[face["norm_idx"][1] - 1]
+            normal_c = self.__normals[face["norm_idx"][2] - 1]
+
+            # obtain ambient colour from material:
+            ka = self.__materials[face["material"]]["Ka"]
+
+            # add triangular vertices to CGO object:
+            cgo_object.extend([
+                COLOR, ka[0], ka[1], ka[2],
+                NORMAL, normal_a[0], normal_a[1], normal_a[2],
+                VERTEX, vertex_a[0], vertex_a[1], vertex_a[2]])
+            cgo_object.extend([
+                COLOR, ka[0], ka[1], ka[2],
+                NORMAL, normal_b[0], normal_b[1], normal_b[2],
+                VERTEX, vertex_b[0], vertex_b[1], vertex_b[2]])
+            cgo_object.extend([
+                COLOR, ka[0], ka[1], ka[2],
+                NORMAL, normal_c[0], normal_c[1], normal_c[2],
+                VERTEX, vertex_c[0], vertex_c[1], vertex_c[2]])
+
+
+        # end this CGO object:
+        cgo_object.extend([END])
+
+        # return CGO obtject:
+        return cgo_object
+
+
+def import_wobj(filename):
+    """ Reads data from OBJ file and returns a dictionary of CGO objects.
+
+    Args:
+        filename: Name of the OBJ file to load.
+
+    Returns:
+        dict: Dictionary of CGO objects where the keys are OBJ group names.
+    """
+
+    # create OBJ importer:
+    obj_importer = WavefrontObjImporter()
+
+    # import data from OBJ file:
+    return obj_importer.read(filename)
+
+
+def draw_wobj(obj, groupname = None):
+    """ Draws a named Compiled Graphics Object (CGO) from a given dictionary.
+
+    Takes a dictionary of Compiled Graphics Objects and a string as input and
+    uses PyMOL functions to draw the CGO associated with a given string. If
+    the name is none (the default) all CGOs in the dictionary will be drawn.
+    This can then be manually hidden or shown using the PyMOL GUI.
+
+    Args:
+        obj: Dictionary of names and Compiled Graphics Objects
+        groupname: Name of the Compiled Graphics Object to draw
+    """
+
+    # delete existing objects under this name:
+    cmd.delete(groupname)
+
+    # has a group name been specified?
+    if groupname != None:
+
+        # load the requested CGO object:
+        cmd.load_cgo(obj[groupname], groupname)
+
+    else:
+
+        # load all CGO objects in dictionary:
+        for key in obj.keys(): cmd.load_cgo(obj[key], key)

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1487,8 +1487,10 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     // read file line by line and calculate summary statistics:
     int linesRead = 0;
     std::string line;
+    std::cout << "inFile " << inFile << " line " << line << std::endl;
     while( std::getline(inFile, line) )
     {
+        std::cout << "while loop touched" << std::endl;
         // read line into JSON document:
         rapidjson::StringStream lineStream(line.c_str());
         rapidjson::Document lineDoc;

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1444,6 +1444,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     std::cout<<std::endl;
 
     // read in tst file
+    std::fstream inFile;
     inFile.open("test.txt", std::fstream::in);
     std::cout << "inFileName test.txt " << inFileName << std::endl;
     std::string line;

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -98,6 +98,7 @@ ChapTrajectoryAnalysis::initOptions(
         IOptionsContainer *options,
         TrajectoryAnalysisSettings *settings)
 {    
+    std::cout << "ChapTrajectoryAnalysis::initOptions " << std::endl;
     // HELP TEXT
     //-------------------------------------------------------------------------
 
@@ -482,6 +483,7 @@ ChapTrajectoryAnalysis::initAnalysis(
         const TrajectoryAnalysisSettings& /*settings*/,
         const TopologyInformation &top)
 {
+    std::cout << "ChapTrajectoryAnalysis::initAnalysis " << std::endl;
     // the following code ensures compatibility across Gromacs versions:
     // (there was an API break between 2016 and 2018)
     #if GROMACS_VERSION_MAJOR>=2018
@@ -846,7 +848,7 @@ ChapTrajectoryAnalysis::initAfterFirstFrame(
         const TrajectoryAnalysisSettings &settings,
         const t_trxframe &fr)
 {
-
+    std::cout << "ChapTrajectoryAnalysis::initAfterFirstFrame blank program... " << std::endl;
 }
 
 
@@ -860,6 +862,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
         t_pbc *pbc,
         TrajectoryAnalysisModuleData *pdata)
 {
+    std::cout << "ChapTrajectoryAnalysis::analyzeFrame " << std::endl;
     // get thread-local selections:
     const Selection &refSelection = pdata -> parallelSelection(pathwaySel_);
 
@@ -1436,6 +1439,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
 void
 ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 {
+    std::cout << "ChapTrajectoryAnalysis::finishAnalysis with argument numFrames " <<  numFrames << std::endl;
     // free line for neater output:
     std::cout<<std::endl;
 
@@ -1488,6 +1492,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     int linesRead = 0;
     std::string line;
     std::cout << "inFile " << inFile << " line " << line << std::endl;
+    std::cout << "getline(inFile, line) " << getline(inFile, line) << std::endl;
     while( std::getline(inFile, line) )
     {
         std::cout << "while loop touched" << std::endl;
@@ -1948,7 +1953,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 void
 ChapTrajectoryAnalysis::writeOutput()
 {
-
+    std::cout << "ChapTrajectoryAnalysis::writeOutput blank..." << std::endl;
 }
 
 
@@ -1960,6 +1965,7 @@ ChapTrajectoryAnalysis::writeOutput()
 void
 ChapTrajectoryAnalysis::obtainNdxFilePathInfo()
 {
+    std::cout << "ChapTrajectoryAnalysis::obtainNdxFilePathInfo " << std::endl;
     // name of index file flag:
     std::string flagName = " -n ";
 
@@ -1989,6 +1995,7 @@ ChapTrajectoryAnalysis::obtainNdxFilePathInfo()
 void
 ChapTrajectoryAnalysis::checkParameters()
 {
+    std::cout << "ChapTrajectoryAnalysis::checkParameters " << std::endl;
     // OUTPUT PARAMETERS
     //-------------------------------------------------------------------------
 

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1572,8 +1572,8 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     {
         //throw std::runtime_error("Number of frames read does not equal number"
         //"of frames analyised.");
-        std::cout << "linesRead" << linesRead <<std::endl;
-        std::cout << "numFrames" << numFrames <<std::endl;
+        std::cout << "linesRead " << linesRead <<std::endl;
+        std::cout << "numFrames " << numFrames <<std::endl;
     }
 
 

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1459,12 +1459,15 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     std::ifstream f(inFileName);
     if (inFile.is_open())
     {
-        std::cout << "print " << inFileName << std::endl;
+        std::cout << "inFile IS open " << inFileName << std::endl;
         // https://stackoverflow.com/questions/35201919/how-do-i-print-out-the-contents-of-a-file-c-file-stream
-        std::cout << "f.rdbuf() " << std::endl;
-        std::cout << f.rdbuf() << std::endl;
-        std::cout << "inFile.rdbuf() "  << std::endl;
-        std::cout << inFile.rdbuf() << std::endl;
+        std::cout << "try f.rdbuf() " << std::endl;
+        try {std::cout << f.rdbuf() << std::endl;}
+        catch (...) { std::cout << "f.rdbuf() not succesful" << std::endl; }
+
+        std::cout << "try inFile.rdbuf() " << std::endl;
+        try {std::cout << inFile.rdbuf() << std::endl;}
+        catch (...) { std::cout << "inFile.rdbuf() not succesful" << std::endl; }
     }
     else {
         std::cout << "inFile is NOT open " << inFileName << std::endl;

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1570,8 +1570,8 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     {
         //throw std::runtime_error("Number of frames read does not equal number"
         //"of frames analyised.");
-        cout << "linesRead" << linesRead;
-        cout << "numFrames" << numFrames;
+        std::cout << "linesRead" << linesRead <<std::endl;
+        std::cout << "numFrames" << numFrames <<std::endl;
     }
 
 

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1831,7 +1831,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     {
         std::string error = "Number of lines read from JSON file does not"
         "equal number of frames processed!";
-        std::cout << std::string error  << std::endl;
+        std::cout << "Number of lines read from JSON file does not equal number of frames processed!"  << std::endl;
         std::cout << "linesProcessed " << linesProcessed  << std::endl;
         std::cout << "numFrames " << numFrames  << std::endl;
         // throw std::runtime_error(error);

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1570,8 +1570,8 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     {
         //throw std::runtime_error("Number of frames read does not equal number"
         //"of frames analyised.");
-        count << "linesRead" << linesRead;
-        count << "numFrames" << numFrames;
+        cout << "linesRead" << linesRead;
+        cout << "numFrames" << numFrames;
     }
 
 

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1458,7 +1458,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     std::cout << "inFile.is_open() " << inFile.is_open() << std::endl;
     if (inFile.is_open())
         std::cout << "print " << inFileName << std::endl;
-        std::cout << inFile.rdbuf();
+        std::cout << inFile.rdbuf() << std::endl;
 
     // prepare summary statistics for aggregate properties:
     SummaryStatistics argMinRadiusSummary;

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1,8 +1,8 @@
 // CHAP - The Channel Annotation Package
-// 
-// Copyright (c) 2016 - 2018 Gianni Klesse, Shanlin Rao, Mark S. P. Sansom, and 
+//
+// Copyright (c) 2016 - 2018 Gianni Klesse, Shanlin Rao, Mark S. P. Sansom, and
 // Stephen J. Tucker
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -12,7 +12,7 @@
 //
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -81,7 +81,7 @@ ChapTrajectoryAnalysis::ChapTrajectoryAnalysis()
 {
     // register data containers:
     registerAnalysisDataset(&frameStreamData_, "frameStreamData");
-    frameStreamData_.setMultipoint(true); 
+    frameStreamData_.setMultipoint(true);
 
     // default initial probe position and chanell direction:
     pfInitProbePos_ = {std::nan(""), std::nan(""), std::nan("")};
@@ -97,7 +97,7 @@ void
 ChapTrajectoryAnalysis::initOptions(
         IOptionsContainer *options,
         TrajectoryAnalysisSettings *settings)
-{    
+{
     std::cout << "ChapTrajectoryAnalysis::initOptions " << std::endl;
     // HELP TEXT
     //-------------------------------------------------------------------------
@@ -201,7 +201,7 @@ ChapTrajectoryAnalysis::initOptions(
 
     const char * const allowedPathFindingMethod[] = {"cylindrical",
                                                      "inplane_optim"};
-    pfMethod_ = ePathFindingMethodInplaneOptimised;                                         
+    pfMethod_ = ePathFindingMethodInplaneOptimised;
     options -> addOption(EnumOption<ePathFindingMethod>("pf-method")
                          .enumValue(allowedPathFindingMethod)
                          .store(&pfMethod_)
@@ -218,7 +218,7 @@ ChapTrajectoryAnalysis::initOptions(
     const char * const allowedVdwRadiusDatabase[] = {"hole_amberuni",
                                                      "hole_bondi",
                                                      "hole_hardcore",
-                                                     "hole_simple", 
+                                                     "hole_simple",
                                                      "hole_xplor",
                                                      "user"};
     pfVdwRadiusDatabase_ = eVdwRadiusDatabaseHoleSimple;
@@ -298,7 +298,7 @@ ChapTrajectoryAnalysis::initOptions(
                          .valueCount(3)
                          .description("Channel direction vector. Will be "
                                       "normalised to unit vector internally."));
-   
+
     // max-free-dist and largest vdW radius
     options -> addOption(DoubleOption("pf-cutoff")
                          .store(&cutoff_)
@@ -309,7 +309,7 @@ ChapTrajectoryAnalysis::initOptions(
                                       "or less means no cutoff is applied. "
                                       "If unset, an appropriate cutoff is "
                                       "determined automatically."));
- 
+
 
 
     // OPTIMISATION PARAMETERS
@@ -328,7 +328,7 @@ ChapTrajectoryAnalysis::initOptions(
                           .defaultValue(0)
                           .description("Number of cooling iterations "
                                        "in one simulated annealing run."));
-                          
+
     options -> addOption(RealOption("sa-init-temp")
                          .store(&pfPar_["saInitTemp"])
                          .defaultValue(0.1)
@@ -395,7 +395,7 @@ ChapTrajectoryAnalysis::initOptions(
                                       "probability density of the solvent "
                                       "particles along the permeation "
                                       "pathway"));
-    
+
     options -> addOption(RealOption("de-res")
                          .store(&deResolution_)
                          .defaultValue(0.01)
@@ -435,7 +435,7 @@ ChapTrajectoryAnalysis::initOptions(
 
     // HYDROPHOBICITY PARAMETERS
     //-------------------------------------------------------------------------
-    
+
     const char * const allowedHydrophobicityDatabase[] = {"hessa_2005",
                                                           "kyte_doolittle_1982",
                                                           "monera_1995",
@@ -467,7 +467,7 @@ ChapTrajectoryAnalysis::initOptions(
                                       "hydrophobicity scale. Will be "
                                       "ignored unless -hydrophobicity-database"
                                       " is set to 'user'."));
-    
+
     options -> addOption(RealOption("hydrophob-bandwidth")
                          .store(&hpBandWidth_)
                          .defaultValue(0.35)
@@ -476,7 +476,7 @@ ChapTrajectoryAnalysis::initOptions(
 
 
 /*!
- * 
+ *
  */
 void
 ChapTrajectoryAnalysis::initAnalysis(
@@ -504,7 +504,7 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // check validity of input parameters:
     checkParameters();
-        
+
     // save atom coordinates in topology for writing to output later:
     outputStructure_.fromTopology(top);
 
@@ -546,19 +546,19 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // prepare container for original path points:
     frameStreamData_.setColumnCount(1, 4);
-    frameStreamColumnNames.push_back({"x", 
+    frameStreamColumnNames.push_back({"x",
                                       "y",
                                       "z",
                                       "r"});
 
     // prepare container for path radius:
     frameStreamData_.setColumnCount(2, 2);
-    frameStreamColumnNames.push_back({"knots", 
+    frameStreamColumnNames.push_back({"knots",
                                       "ctrl"});
 
     // prepare container for pathway spline:
     frameStreamData_.setColumnCount(3, 4);
-    frameStreamColumnNames.push_back({"knots", 
+    frameStreamColumnNames.push_back({"knots",
                                       "ctrlX",
                                       "ctrlY",
                                       "ctrlZ"});
@@ -579,7 +579,7 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // prepare container for solvent mapping:
     frameStreamData_.setColumnCount(5, 9);
-    frameStreamColumnNames.push_back({"resId", 
+    frameStreamColumnNames.push_back({"resId",
                                       "s",
                                       "rho",
                                       "phi",
@@ -591,15 +591,15 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // prepare container for solvent density:
     frameStreamData_.setColumnCount(6, 2);
-    frameStreamColumnNames.push_back({"knots", 
+    frameStreamColumnNames.push_back({"knots",
                                       "ctrl"});
 
     // prepare container for hydrophobicity splines:
     frameStreamData_.setColumnCount(7, 2);
-    frameStreamColumnNames.push_back({"knots", 
+    frameStreamColumnNames.push_back({"knots",
                                       "ctrl"});
     frameStreamData_.setColumnCount(8, 2);
-    frameStreamColumnNames.push_back({"knots", 
+    frameStreamColumnNames.push_back({"knots",
                                       "ctrl"});
 
     // add JSON exporter to frame stream data:
@@ -617,7 +617,7 @@ ChapTrajectoryAnalysis::initAnalysis(
     // prepare a centre of geometry selection collection:
     poreMappingSelCol_.setReferencePosType("res_cog");
     poreMappingSelCol_.setOutputPosType("res_cog");
-  
+
     // selection of C-alpha atoms:
     std::string pathwaySelSelText = pathwaySel_.selectionText();
     std::string poreMappingSelCalString = pfSelString_;
@@ -625,19 +625,19 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // create index groups from topology:
     gmx_ana_indexgrps_t *poreIdxGroups;
- 
+
     // has external index file been specified?
     if( customNdxFileName_.size() != 0 )
     {
-        gmx_ana_indexgrps_init(&poreIdxGroups, 
-                               topologyPointer.get(), 
-                               customNdxFileName_.c_str());  
+        gmx_ana_indexgrps_init(&poreIdxGroups,
+                               topologyPointer.get(),
+                               customNdxFileName_.c_str());
     }
     else
     {
-        gmx_ana_indexgrps_init(&poreIdxGroups, 
-                               topologyPointer.get(), 
-                               NULL); 
+        gmx_ana_indexgrps_init(&poreIdxGroups,
+                               topologyPointer.get(),
+                               NULL);
     }
 
     // create selections as defined above:
@@ -653,7 +653,7 @@ ChapTrajectoryAnalysis::initAnalysis(
     // do we have one C-alpha for each pore-forming residue?
     if( poreMappingSelCal_.posCount() != poreMappingSelCog_.posCount() )
     {
-        findPfResidues_ = false;  
+        findPfResidues_ = false;
     }
     else
     {
@@ -704,7 +704,7 @@ ChapTrajectoryAnalysis::initAnalysis(
         gmx_ana_indexgrps_free(solvIdxGroups);
     }
 
-    
+
     // GET ATOM RADII FROM TOPOLOGY
     //-------------------------------------------------------------------------
 
@@ -744,10 +744,10 @@ ChapTrajectoryAnalysis::initAnalysis(
         }
     }
 
-    // import vdW radii JSON: 
+    // import vdW radii JSON:
     JsonDocImporter jdi;
     rapidjson::Document radiiDoc = jdi(pfVdwRadiusJson_.c_str());
-   
+
     // create radius provider and build lookup table:
     VdwRadiusProvider vrp;
     vrp.lookupTableFromJson(radiiDoc);
@@ -763,7 +763,7 @@ ChapTrajectoryAnalysis::initAnalysis(
             pathwaySel_.mappedIds().data(),
             pathwaySel_.mappedIds().data() + pathwaySel_.mappedIds().size());
 
-    
+
 
     // build vdw radius lookup map:
     vdwRadii_ = vrp.vdwRadiiForTopology(top, mappedIds);
@@ -780,9 +780,9 @@ ChapTrajectoryAnalysis::initAnalysis(
     resInfo_.chainFromTopology(top);
 
     // base path to location of hydrophobicity databases:
-    std::string hydrophobicityFilePath = chapInstallBase() + 
+    std::string hydrophobicityFilePath = chapInstallBase() +
             std::string("/chap/share/data/hydrophobicity/");
-    
+
     // select appropriate database file:
     if( hydrophobicityDatabase_ == eHydrophobicityDatabaseHessa2005 )
     {
@@ -825,7 +825,7 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // import hydrophbicity JSON:
     rapidjson::Document hydrophobicityDoc = jdi(hydrophobicityJson_.c_str());
-   
+
     // generate hydrophobicity lookup table:
     resInfo_.hydrophobicityFromJson(hydrophobicityDoc);
 
@@ -857,8 +857,8 @@ ChapTrajectoryAnalysis::initAfterFirstFrame(
  */
 void
 ChapTrajectoryAnalysis::analyzeFrame(
-        int frnr, 
-        const t_trxframe &fr, 
+        int frnr,
+        const t_trxframe &fr,
         t_pbc *pbc,
         TrajectoryAnalysisModuleData *pdata)
 {
@@ -878,30 +878,30 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // recalculate initial probe position based on reference group COG:
     if( pfInitProbePosIsSet_ == false )
-    {  
+    {
         // helper variable for conditional assignment of selection:
         Selection tmpsel;
-  
+
         // has a group for specifying initial probe position been set?
         if( ippSelIsSet_ == true )
         {
             // use explicitly given selection:
             tmpsel = ippSel_;
         }
-        else 
+        else
         {
             // default to overall group of pore forming particles:
             tmpsel = pathwaySel_;
         }
-     
+
         // load data into initial position selection:
         const gmx::Selection &initPosSelection = pdata -> parallelSelection(tmpsel);
- 
+
         // initialse total mass and COM vector:
         real totalMass = 0.0;
         gmx::RVec centreOfMass(0.0, 0.0, 0.0);
-        
-        // loop over all atoms: 
+
+        // loop over all atoms:
         for(int i = 0; i < initPosSelection.atomCount(); i++)
         {
             // get i-th atom position:
@@ -919,7 +919,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
         // scale COM vector by total MASS:
         centreOfMass[XX] /= 1.0 * totalMass;
         centreOfMass[YY] /= 1.0 * totalMass;
-        centreOfMass[ZZ] /= 1.0 * totalMass; 
+        centreOfMass[ZZ] /= 1.0 * totalMass;
 
         // set initial probe position:
         pfInitProbePos_[XX] = centreOfMass[XX];
@@ -952,7 +952,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // vectors as RVec:
     RVec initProbePos(pfInitProbePos_[0], pfInitProbePos_[1], pfInitProbePos_[2]);
-    RVec chanDirVec(pfChanDirVec_[0], pfChanDirVec_[1], pfChanDirVec_[2]); 
+    RVec chanDirVec(pfChanDirVec_[0], pfChanDirVec_[1], pfChanDirVec_[2]);
 
     // create path finding module:
     std::unique_ptr<AbstractPathFinder> pfm;
@@ -964,10 +964,10 @@ ChapTrajectoryAnalysis::analyzeFrame(
                                                       chanDirVec,
                                                       pbc,
                                                       refSelection,
-                                                      selVdwRadii));        
+                                                      selVdwRadii));
     }
     else if( pfMethod_ == ePathFindingMethodNaiveCylindrical )
-    {        
+    {
         // create the naive cylindrical path finder:
         pfm.reset(new NaiveCylindricalPathFinder(pfPar_,
                                                  initProbePos,
@@ -992,7 +992,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
     clock_t tMolPath = std::clock();
     MolecularPath molPath = pfm -> getMolecularPath();
     tMolPath = (std::clock() - tMolPath)/CLOCKS_PER_SEC;
-    
+
     // which method do we use for path alignment?
     if( pfPathAlignmentMethod_ == ePathAlignmentMethodNone )
     {
@@ -1026,7 +1026,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // add radius spline knots and control points to frame stream dataset:
     dhFrameStream.selectDataSet(2);
-    std::vector<real> radiusKnots = molPath.poreRadiusUniqueKnots();    
+    std::vector<real> radiusKnots = molPath.poreRadiusUniqueKnots();
     std::vector<real> radiusCtrlPoints = molPath.poreRadiusCtrlPoints();
     for(size_t i = 0; i < radiusKnots.size(); i++)
     {
@@ -1034,10 +1034,10 @@ ChapTrajectoryAnalysis::analyzeFrame(
         dhFrameStream.setPoint(1, radiusCtrlPoints.at(i));
         dhFrameStream.finishPointSet();
     }
-    
+
     // add centre line spline knots and control points to frame stream dataset:
     dhFrameStream.selectDataSet(3);
-    std::vector<real> centreLineKnots = molPath.centreLineUniqueKnots();    
+    std::vector<real> centreLineKnots = molPath.centreLineUniqueKnots();
     std::vector<gmx::RVec> centreLineCtrlPoints = molPath.centreLineCtrlPoints();
     for(size_t i = 0; i < centreLineKnots.size(); i++)
     {
@@ -1051,12 +1051,12 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // MAP PORE PARTICLES ONTO PATHWAY
     //-------------------------------------------------------------------------
- 
+
     // evaluate pore mapping selection for this frame:
     t_trxframe frame = fr;
     poreMappingSelCol_.evaluate(&frame, pbc);
-    const gmx::Selection poreMappingSelCal = pdata -> parallelSelection(poreMappingSelCal_);    
-    const gmx::Selection poreMappingSelCog = pdata -> parallelSelection(poreMappingSelCog_);    
+    const gmx::Selection poreMappingSelCal = pdata -> parallelSelection(poreMappingSelCal_);
+    const gmx::Selection poreMappingSelCog = pdata -> parallelSelection(poreMappingSelCog_);
 
 
     // map pore residue COG onto pathway:
@@ -1071,11 +1071,11 @@ ChapTrajectoryAnalysis::analyzeFrame(
             poreMappingSelCal);
     tMapResCal = (std::clock() - tMapResCal)/CLOCKS_PER_SEC;
 
-    
+
     // check if particles are pore-lining:
     clock_t tResPoreLining = std::clock();
     std::map<int, bool> poreLining = molPath.checkIfInside(
-            poreCogMappedCoords, 
+            poreCogMappedCoords,
             poreMappingMargin_);
     int nPoreLining = 0;
     for(auto jt = poreLining.begin(); jt != poreLining.end(); jt++)
@@ -1089,7 +1089,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // check if residues are pore-facing:
     // TODO: make this conditional on whether C-alphas are available
-    
+
     clock_t tResPoreFacing = std::clock();
     std::map<int, bool> poreFacing;
     int nPoreFacing = 0;
@@ -1105,15 +1105,15 @@ ChapTrajectoryAnalysis::analyzeFrame(
         }
         else
         {
-            poreFacing[it->first] = false;            
+            poreFacing[it->first] = false;
         }
     }
     tResPoreFacing = (std::clock() - tResPoreFacing)/CLOCKS_PER_SEC;
-    
+
 
     // ESTIMATE HYDROPHOBICITY PROFILE
     //-------------------------------------------------------------------------
-   
+
     // get vectors of coordinates of pore-facing and -lining residues:
     std::vector<real> plResidueCoordS;
     std::vector<real> plResidueHydrophobicity;
@@ -1164,36 +1164,36 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // estimate hydrophobicity profiles due to pore-lining residues:
     SplineCurve1D plHydrophobicity = kernelSmoother.estimate(
-            plResidueCoordS, 
+            plResidueCoordS,
             plResidueHydrophobicity);
 
-    // add spline curve parameters to data handle:   
+    // add spline curve parameters to data handle:
     dhFrameStream.selectDataSet(7);
     for(size_t i = 0; i < plHydrophobicity.ctrlPoints().size(); i++)
     {
         dhFrameStream.setPoint(
-                0, 
+                0,
                 plHydrophobicity.uniqueKnots().at(i));
         dhFrameStream.setPoint(
-                1, 
+                1,
                 plHydrophobicity.ctrlPoints().at(i));
         dhFrameStream.finishPointSet();
     }
 
     // estimate hydrophobicity profiles due to pore-facing residues:
     SplineCurve1D pfHydrophobicity = kernelSmoother.estimate(
-            pfResidueCoordS, 
+            pfResidueCoordS,
             pfResidueHydrophobicity);
 
-    // add spline curve parameters to data handle:   
+    // add spline curve parameters to data handle:
     dhFrameStream.selectDataSet(8);
     for(size_t i = 0; i < pfHydrophobicity.ctrlPoints().size(); i++)
     {
         dhFrameStream.setPoint(
-                0, 
+                0,
                 pfHydrophobicity.uniqueKnots().at(i));
         dhFrameStream.setPoint(
-                1, 
+                1,
                 pfHydrophobicity.ctrlPoints().at(i));
         dhFrameStream.finishPointSet();
     }
@@ -1203,7 +1203,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
     //-------------------------------------------------------------------------
 
     // create data containers:
-    std::map<int, gmx::RVec> solventMappedCoords; 
+    std::map<int, gmx::RVec> solventMappedCoords;
     std::map<int, bool> solvInsideSample;
     std::map<int, bool> solvInsidePore;
     int numSolvInsideSample = 0;
@@ -1218,7 +1218,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
         // TODO: make this a parameter:
         real solvMappingMargin_ = 0.0;
-            
+
         // get thread-local selection data:
         const Selection solvMapSel = pdata -> parallelSelection(solvMappingSelCog_);
 
@@ -1230,10 +1230,10 @@ ChapTrajectoryAnalysis::analyzeFrame(
         // find particles inside path (i.e. pore plus bulk sampling regime):
         clock_t tSolInsideSample = std::clock();
         solvInsideSample = molPath.checkIfInside(
-                solventMappedCoords, 
+                solventMappedCoords,
                 solvMappingMargin_);
         for(auto jt = solvInsideSample.begin(); jt != solvInsideSample.end(); jt++)
-        {            
+        {
             if( jt -> second == true )
             {
                 numSolvInsideSample++;
@@ -1244,12 +1244,12 @@ ChapTrajectoryAnalysis::analyzeFrame(
         // find particles inside pore:
         clock_t tSolInsidePore = std::clock();
         solvInsidePore = molPath.checkIfInside(
-                solventMappedCoords, 
+                solventMappedCoords,
                 solvMappingMargin_,
                 molPath.sLo(),
                 molPath.sHi());
         for(auto jt = solvInsidePore.begin(); jt != solvInsidePore.end(); jt++)
-        {            
+        {
             if( jt -> second == true )
             {
                 numSolvInsidePore++;
@@ -1259,16 +1259,16 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
         // now add mapped residue coordinates to data handle:
         dhFrameStream.selectDataSet(5);
-        
+
         // add mapped residues to data container:
-        for(auto it = solventMappedCoords.begin(); 
-            it != solventMappedCoords.end(); 
+        for(auto it = solventMappedCoords.begin();
+            it != solventMappedCoords.end();
             it++)
         {
              dhFrameStream.setPoint(0, solvMapSel.position(it -> first).mappedId()); // res.id
              dhFrameStream.setPoint(1, it -> second[0]);     // s
              dhFrameStream.setPoint(2, it -> second[1]);     // rho
-             dhFrameStream.setPoint(3, 0.0);                 // phi 
+             dhFrameStream.setPoint(3, 0.0);                 // phi
              dhFrameStream.setPoint(4, solvInsidePore[it -> first]);        // inside pore
              dhFrameStream.setPoint(5, solvInsideSample[it -> first]);      // inside sample
              dhFrameStream.setPoint(6, solvMapSel.position(it -> first).x()[XX]);  // x
@@ -1278,7 +1278,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
         }
     }
 
-    
+
     // ESTIMATE SOLVENT DENSITY
     //-------------------------------------------------------------------------
 
@@ -1334,15 +1334,15 @@ ChapTrajectoryAnalysis::analyzeFrame(
     SplineCurve1D solventDensityCoordS = densityEstimator -> estimate(
             solventSampleCoordS);
 
-    // add spline curve parameters to data handle:   
+    // add spline curve parameters to data handle:
     dhFrameStream.selectDataSet(6);
     for(size_t i = 0; i < solventDensityCoordS.ctrlPoints().size(); i++)
     {
         dhFrameStream.setPoint(
-                0, 
+                0,
                 solventDensityCoordS.uniqueKnots().at(i));
         dhFrameStream.setPoint(
-                1, 
+                1,
                 solventDensityCoordS.ctrlPoints().at(i));
         dhFrameStream.finishPointSet();
     }
@@ -1355,17 +1355,17 @@ ChapTrajectoryAnalysis::analyzeFrame(
     SplineCurve1D pathRadius = molPath.pathRadius();
     NumberDensityCalculator ncc;
     SplineCurve1D numberDensity = ncc(
-            solventDensityCoordS, 
-            pathRadius, 
+            solventDensityCoordS,
+            pathRadius,
             numSolvInsideSample);
-  
+
     // find minimum instantaneous solvent density in this frame:
     std::pair<real, real> lim(molPath.sLo(), molPath.sHi());
     std::pair<real, real> minSolventDensity = numberDensity.minimum(lim);
 
 
     // ADD AGGREGATE DATA TO PARALLELISABLE CONTAINER
-    //-------------------------------------------------------------------------   
+    //-------------------------------------------------------------------------
 
     // add aggegate path data:
     dhFrameStream.selectDataSet(0);
@@ -1376,13 +1376,13 @@ ChapTrajectoryAnalysis::analyzeFrame(
     dhFrameStream.setPoint(2, molPath.minRadius().second);
     dhFrameStream.setPoint(3, molPath.length());
     dhFrameStream.setPoint(4, molPath.volume());
-    dhFrameStream.setPoint(5, numSolvInsidePore); 
-    dhFrameStream.setPoint(6, numSolvInsideSample); 
-    dhFrameStream.setPoint(7, solventRangeLo); 
+    dhFrameStream.setPoint(5, numSolvInsidePore);
+    dhFrameStream.setPoint(6, numSolvInsideSample);
+    dhFrameStream.setPoint(7, solventRangeLo);
     dhFrameStream.setPoint(8, solventRangeHi);
-    dhFrameStream.setPoint(9, minSolventDensity.first); 
+    dhFrameStream.setPoint(9, minSolventDensity.first);
     dhFrameStream.setPoint(10, minSolventDensity.second);
-    dhFrameStream.setPoint(11, molPath.sLo()); 
+    dhFrameStream.setPoint(11, molPath.sLo());
     dhFrameStream.setPoint(12, molPath.sHi());
     dhFrameStream.setPoint(13, deParams_.bandWidth()*deParams_.bandWidthScale());
     dhFrameStream.finishPointSet();
@@ -1454,6 +1454,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
     // openen per-frame data set for reading:
     inFile.open(inFileName, std::fstream::in);
+    std::cout << "inFileName " << inFileName << std::endl;
 
     // prepare summary statistics for aggregate properties:
     SummaryStatistics argMinRadiusSummary;
@@ -1491,8 +1492,9 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     // read file line by line and calculate summary statistics:
     int linesRead = 0;
     std::string line;
+    std::cout << "std::getline(inFile, line) " << std::getline(inFile, line) << std::endl;
+    std::cout << "return value = input (the stream to get data from , here inFile) " << std::endl;
     std::cout << "inFile " << inFile << " line " << line << std::endl;
-    std::cout << "getline(inFile, line) " << getline(inFile, line) << std::endl;
     while( std::getline(inFile, line) )
     {
         std::cout << "while loop touched" << std::endl;
@@ -1505,11 +1507,11 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         if( !lineDoc.IsObject() )
         {
             // FIXME this is where the JSON error occurs
-            std::string error = "Line " + std::to_string(linesRead) + 
+            std::string error = "Line " + std::to_string(linesRead) +
             " read from" + inFileName + " is not valid JSON object.";
             throw std::runtime_error(error);
         }
-    
+
         // calculate summary statistics of aggregate variables:
         argMinRadiusSummary.update(
                 lineDoc["pathSummary"]["argMinRadius"][0].GetDouble());
@@ -1537,7 +1539,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
                 lineDoc["pathSummary"]["arcLengthHi"][0].GetDouble());
         bandWidthSummary.update(
                 lineDoc["pathSummary"]["bandWidth"][0].GetDouble());
-        
+
         // get time stamp of current frame:
         real timeStamp = lineDoc["pathSummary"]["timeStamp"][0].GetDouble();
         timeStamps.push_back(timeStamp);
@@ -1571,7 +1573,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
     // close per frame data set:
     inFile.close();
-    
+
     // sanity check:
     if( linesRead != numFrames )
     {
@@ -1606,7 +1608,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
     // open JSON data file in read mode:
     inFile.open(inFileName.c_str(), std::fstream::in);
-    
+
     // prepare containers for profile summaries:
     std::vector<SummaryStatistics> radiusSummary(supportPoints.size());
     std::vector<SummaryStatistics> solventDensitySummary(supportPoints.size());
@@ -1626,7 +1628,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     std::vector<SummaryStatistics> residueYSummary(numPoreRes);
     std::vector<SummaryStatistics> residueZSummary(numPoreRes);
 
-    // containers for profile valued time series: 
+    // containers for profile valued time series:
     std::vector<std::vector<real>> radiusProfileTimeSeries;
     std::vector<std::vector<real>> solventDensityTimeSeries;
     std::vector<std::vector<real>> plHydrophobicityTimeSeries;
@@ -1650,7 +1652,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         // sanity checks:
         if( !lineDoc.IsObject() )
         {
-            std::string error = "Line " + std::to_string(linesProcessed) + 
+            std::string error = "Line " + std::to_string(linesProcessed) +
             " read from" + inFileName + " is not valid JSON object.";
             throw std::runtime_error(error);
         }
@@ -1666,7 +1668,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         MolecularPath molPath(lineDoc);
 
         // sample radius at support points and add to summary statistics:
-        std::vector<real> radiusSample = molPath.sampleRadii(supportPoints); 
+        std::vector<real> radiusSample = molPath.sampleRadii(supportPoints);
         for(size_t i = 0; i < radiusSample.size(); i++)
         {
             radiusSummary.at(i).update(radiusSample.at(i));
@@ -1675,11 +1677,11 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         // add to time series:
         radiusProfileTimeSeries.push_back(radiusSample);
 
-        
+
         // sample points from hydrophobicity splines:
         SplineCurve1D pfHydrophobicitySpline = SplineCurve1DJsonConverter::fromJson(
                 lineDoc["pfHydrophobicitySpline"], 1);
-        std::vector<real> pfHydrophobicitySample = 
+        std::vector<real> pfHydrophobicitySample =
                 pfHydrophobicitySpline.evaluateMultiple(supportPoints, 0);
         SummaryStatistics::updateMultiple(
                 pfHydrophobicitySummary,
@@ -1688,7 +1690,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
         SplineCurve1D plHydrophobicitySpline = SplineCurve1DJsonConverter::fromJson(
                 lineDoc["plHydrophobicitySpline"], 1);
-        std::vector<real> plHydrophobicitySample = 
+        std::vector<real> plHydrophobicitySample =
                 plHydrophobicitySpline.evaluateMultiple(supportPoints, 0);
         SummaryStatistics::updateMultiple(
                 plHydrophobicitySummary,
@@ -1699,7 +1701,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         // sample points from solvent density spline:
         SplineCurve1D solventDensitySpline = SplineCurve1DJsonConverter::fromJson(
                 lineDoc["solventDensitySpline"], 1);
-        std::vector<real> solventDensitySample = 
+        std::vector<real> solventDensitySample =
                 solventDensitySpline.evaluateMultiple(supportPoints, 0);
 
         // get total number of particles in sample for this time step:
@@ -1709,14 +1711,14 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         // TODO this should be done in per-frame analysis:
         NumberDensityCalculator ndc;
         solventDensitySample = ndc(
-                solventDensitySample, 
-                radiusSample, 
+                solventDensitySample,
+                radiusSample,
                 totalNumber);
         SummaryStatistics::updateMultiple(
                 solventDensitySummary,
                 solventDensitySample);
         solventDensityTimeSeries.push_back(solventDensitySample);
- 
+
         // convert to energy and add to summary statistic:
         BoltzmannEnergyCalculator bec;
         std::vector<real> energySample = bec.calculate(solventDensitySample);
@@ -1769,12 +1771,12 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         // increment line counter:
         linesProcessed++;
     }
-  
+
     // shift of energy profile so that energy at anchor points is zero:
     real shift = -0.5*(anchorEnergyLo.mean() + anchorEnergyHi.mean());
     std::for_each(
-            energySummary.begin(), 
-            energySummary.end(), 
+            energySummary.begin(),
+            energySummary.end(),
             [this, shift](SummaryStatistics &s){s.shift(shift);});
 
     // inform user about progress:
@@ -1788,14 +1790,14 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     if( linesProcessed != numFrames )
     {
         std::string error = "Number of lines read from JSON file does not"
-        "equal number of frames processed!"; 
+        "equal number of frames processed!";
         throw std::runtime_error(error);
     }
 
     // close filestream object:
     inFile.close();
 
-    
+
     // CREATE PDB OUTPUT
     // ------------------------------------------------------------------------
 
@@ -1830,7 +1832,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     results.addPathwayProfile("pfHydrophobicity", pfHydrophobicitySummary);
     results.addPathwayProfile("density", solventDensitySummary);
     results.addPathwayProfile("energy", energySummary);
-    
+
     // add scalar time series data to output:
     results.addTimeStamps(timeStamps);
     results.addPathwayScalarTimeSeries("argMinRadius", argMinRadiusTimeSeries);
@@ -1870,7 +1872,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
     // DELETE PER FRAME DATA
     // ------------------------------------------------------------------------
-   
+
     // detailed output requested?
     if( !outputDetailed_ )
     {
@@ -1899,24 +1901,24 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     // averaged properties as spline curves:
     CubicSplineInterp1D interp;
     auto avgRadiusSpl = interp(
-            supportPoints, 
-            avgRadius, 
+            supportPoints,
+            avgRadius,
             eSplineInterpBoundaryHermite);
     auto avgSolventDensitySpl = interp(
-            supportPoints, 
-            avgSolventDensity, 
+            supportPoints,
+            avgSolventDensity,
             eSplineInterpBoundaryHermite);
     auto avgEnergySpl = interp(
-            supportPoints, 
-            avgEnergy, 
+            supportPoints,
+            avgEnergy,
             eSplineInterpBoundaryHermite);
     auto avgPlHydrophobicitySpl = interp(
-            supportPoints, 
-            avgPlHydrophobicity, 
+            supportPoints,
+            avgPlHydrophobicity,
             eSplineInterpBoundaryHermite);
     auto avgPfHydrophobicitySpl = interp(
-            supportPoints, 
-            avgPfHydrophobicity, 
+            supportPoints,
+            avgPfHydrophobicity,
             eSplineInterpBoundaryHermite);
 
 
@@ -1929,7 +1931,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     molPathAvg_ -> addScalarProperty("avg_pf_hydrophobicity", avgPfHydrophobicitySpl, true);
 
     // load colour palettes from JSON file:
-    std::string paletteFilePath = chapInstallBase() + 
+    std::string paletteFilePath = chapInstallBase() +
             std::string("/chap/share/data/palettes/");
     std::string paletteFileName = paletteFilePath + "default.json";
     auto palettes = ColourPaletteProvider::fromJsonFile(paletteFileName);
@@ -1940,8 +1942,8 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     mpexp.setGridSampleDist(outputGridSampleDist_);
     mpexp.setCorrectionThreshold(outputCorrectionThreshold_);
     mpexp(
-        outputBaseFileName_, 
-        "time_averaged_molecular_path", 
+        outputBaseFileName_,
+        "time_averaged_molecular_path",
         *molPathAvg_,
         palettes);
 }
@@ -1988,8 +1990,8 @@ ChapTrajectoryAnalysis::obtainNdxFilePathInfo()
 }
 
 
-/*! 
- * Auxiliary function for checking the validity of various input parameters. 
+/*!
+ * Auxiliary function for checking the validity of various input parameters.
  * Bundled here to keep initAnalysis() uncluttered.
  */
 void
@@ -2015,7 +2017,7 @@ ChapTrajectoryAnalysis::checkParameters()
         throw std::runtime_error("Parameter -out-grid-dist must be strictly "
                                  "positive.");
     }
-    if( outputCorrectionThreshold_ >= 1.0 or 
+    if( outputCorrectionThreshold_ >= 1.0 or
         outputCorrectionThreshold_ <= -1.0)
     {
         throw std::runtime_error("Parameter -out-vis-teak must be in interval "
@@ -2050,7 +2052,7 @@ ChapTrajectoryAnalysis::checkParameters()
     pfParams_.setProbeStepLength(pfProbeStepLength_);
     pfParams_.setMaxProbeRadius(pfMaxProbeRadius_);
     pfParams_.setMaxProbeSteps(pfMaxProbeSteps_);
-    
+
     if( cutoffIsSet_ )
     {
         // this will be determined automatically if not set explcitly:
@@ -2075,7 +2077,7 @@ ChapTrajectoryAnalysis::checkParameters()
         deParams_.setMaxEvalPointDist(deResolution_);
     }
 
-    
+
     // HYDROPHOBICITY PARAMETERS
     //-------------------------------------------------------------------------
 
@@ -2087,4 +2089,3 @@ ChapTrajectoryAnalysis::checkParameters()
     hydrophobKernelParams_.setEvalRangeCutoff(hpEvalRangeCutoff_);
     hydrophobKernelParams_.setMaxEvalPointDist(hpResolution_);
 }
-

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1463,10 +1463,16 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         // https://stackoverflow.com/questions/35201919/how-do-i-print-out-the-contents-of-a-file-c-file-stream
         std::cout << "try f.rdbuf() " << std::endl;
         try {std::cout << f.rdbuf() << std::endl;}
+        catch (const std::exception& e) {
+          std::cout << " a standard exception was caught, with message '"  << e.what() << std::endl;
+        }
         catch (...) { std::cout << "f.rdbuf() not succesful" << std::endl; }
 
         std::cout << "try inFile.rdbuf() " << std::endl;
         try {std::cout << inFile.rdbuf() << std::endl;}
+        catch (const std::exception& e) {
+          std::cout << " a standard exception was caught, with message '"  << e.what() << std::endl;
+        }
         catch (...) { std::cout << "inFile.rdbuf() not succesful" << std::endl; }
     }
     else {

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1615,6 +1615,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     {
         //throw std::runtime_error("Number of frames read does not equal number"
         //"of frames analyised.");
+        std::cout << "Number of frames read does not equal number of frames analyised" <<std::endl;
         std::cout << "linesRead " << linesRead <<std::endl;
         std::cout << "numFrames " << numFrames <<std::endl;
     }
@@ -1644,6 +1645,8 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
     // open JSON data file in read mode:
     inFile.open(inFileName.c_str(), std::fstream::in);
+    std::cout << " open JSON data file in read mode: inFileName.c_str() " << inFileName.c_str() <<std::endl;
+    std::cout << "inFile.is_open() " << inFile.is_open() << std::endl;
 
     // prepare containers for profile summaries:
     std::vector<SummaryStatistics> radiusSummary(supportPoints.size());
@@ -1672,6 +1675,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
     // read file line by line:
     int linesProcessed = 0;
+    std::cout << "std::getline(inFile, line) " << std::getline(inFile, line) << std::endl;
     while( std::getline(inFile, line) )
     {
         std::cout.precision(3);
@@ -1827,7 +1831,10 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     {
         std::string error = "Number of lines read from JSON file does not"
         "equal number of frames processed!";
-        throw std::runtime_error(error);
+        std::cout << std::string error  << std::endl;
+        std::cout << "linesProcessed " << linesProcessed  << std::endl;
+        std::cout << "numFrames " << numFrames  << std::endl;
+        // throw std::runtime_error(error);
     }
 
     // close filestream object:
@@ -2040,6 +2047,7 @@ ChapTrajectoryAnalysis::checkParameters()
     // add proper extensions to file names:
     // TODO: better in exporter code?
     outputJsonFileName_ = outputBaseFileName_ + ".json";
+    std::cout << "outputJsonFileName_ " << outputJsonFileName_ << std::endl;
     outputPdbFileName_ = outputBaseFileName_ + ".pdb";
 
     // sanity checks:

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1462,18 +1462,18 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         std::cout << "inFile IS open " << inFileName << std::endl;
         // https://stackoverflow.com/questions/35201919/how-do-i-print-out-the-contents-of-a-file-c-file-stream
         std::cout << "try f.rdbuf() " << std::endl;
-        try {std::cout << f.rdbuf() << std::endl;}
-        catch (const std::exception& e) {
-          std::cout << " a standard exception was caught, with message '"  << e.what() << std::endl;
-        }
-        catch (...) { std::cout << "f.rdbuf() not succesful" << std::endl; }
+        //try {std::cout << f.rdbuf() << std::endl;}
+        //catch (const std::exception& e) {
+        //  std::cout << " a standard exception was caught, with message '"  << e.what() << std::endl;
+        //}
+        //catch (...) { std::cout << "f.rdbuf() not succesful" << std::endl; }
 
         std::cout << "try inFile.rdbuf() " << std::endl;
-        try {std::cout << inFile.rdbuf() << std::endl;}
-        catch (const std::exception& e) {
-          std::cout << " a standard exception was caught, with message '"  << e.what() << std::endl;
-        }
-        catch (...) { std::cout << "inFile.rdbuf() not succesful" << std::endl; }
+        //try {std::cout << inFile.rdbuf() << std::endl;}
+        //catch (const std::exception& e) {
+        //  std::cout << " a standard exception was caught, with message '"  << e.what() << std::endl;
+        //}
+        //catch (...) { std::cout << "inFile.rdbuf() not succesful" << std::endl; }
     }
     else {
         std::cout << "inFile is NOT open " << inFileName << std::endl;

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1568,8 +1568,10 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     // sanity check:
     if( linesRead != numFrames )
     {
-        throw std::runtime_error("Number of frames read does not equal number"
-        "of frames analyised.");
+        //throw std::runtime_error("Number of frames read does not equal number"
+        //"of frames analyised.");
+        count << "linesRead" << linesRead;
+        count << "numFrames" << numFrames;
     }
 
 

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1,8 +1,8 @@
 // CHAP - The Channel Annotation Package
-//
-// Copyright (c) 2016 - 2018 Gianni Klesse, Shanlin Rao, Mark S. P. Sansom, and
+// 
+// Copyright (c) 2016 - 2018 Gianni Klesse, Shanlin Rao, Mark S. P. Sansom, and 
 // Stephen J. Tucker
-//
+// 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -12,7 +12,7 @@
 //
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-//
+// 
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -81,7 +81,7 @@ ChapTrajectoryAnalysis::ChapTrajectoryAnalysis()
 {
     // register data containers:
     registerAnalysisDataset(&frameStreamData_, "frameStreamData");
-    frameStreamData_.setMultipoint(true);
+    frameStreamData_.setMultipoint(true); 
 
     // default initial probe position and chanell direction:
     pfInitProbePos_ = {std::nan(""), std::nan(""), std::nan("")};
@@ -97,8 +97,7 @@ void
 ChapTrajectoryAnalysis::initOptions(
         IOptionsContainer *options,
         TrajectoryAnalysisSettings *settings)
-{
-    std::cout << "ChapTrajectoryAnalysis::initOptions " << std::endl;
+{    
     // HELP TEXT
     //-------------------------------------------------------------------------
 
@@ -201,7 +200,7 @@ ChapTrajectoryAnalysis::initOptions(
 
     const char * const allowedPathFindingMethod[] = {"cylindrical",
                                                      "inplane_optim"};
-    pfMethod_ = ePathFindingMethodInplaneOptimised;
+    pfMethod_ = ePathFindingMethodInplaneOptimised;                                         
     options -> addOption(EnumOption<ePathFindingMethod>("pf-method")
                          .enumValue(allowedPathFindingMethod)
                          .store(&pfMethod_)
@@ -218,7 +217,7 @@ ChapTrajectoryAnalysis::initOptions(
     const char * const allowedVdwRadiusDatabase[] = {"hole_amberuni",
                                                      "hole_bondi",
                                                      "hole_hardcore",
-                                                     "hole_simple",
+                                                     "hole_simple", 
                                                      "hole_xplor",
                                                      "user"};
     pfVdwRadiusDatabase_ = eVdwRadiusDatabaseHoleSimple;
@@ -298,7 +297,7 @@ ChapTrajectoryAnalysis::initOptions(
                          .valueCount(3)
                          .description("Channel direction vector. Will be "
                                       "normalised to unit vector internally."));
-
+   
     // max-free-dist and largest vdW radius
     options -> addOption(DoubleOption("pf-cutoff")
                          .store(&cutoff_)
@@ -309,7 +308,7 @@ ChapTrajectoryAnalysis::initOptions(
                                       "or less means no cutoff is applied. "
                                       "If unset, an appropriate cutoff is "
                                       "determined automatically."));
-
+ 
 
 
     // OPTIMISATION PARAMETERS
@@ -328,7 +327,7 @@ ChapTrajectoryAnalysis::initOptions(
                           .defaultValue(0)
                           .description("Number of cooling iterations "
                                        "in one simulated annealing run."));
-
+                          
     options -> addOption(RealOption("sa-init-temp")
                          .store(&pfPar_["saInitTemp"])
                          .defaultValue(0.1)
@@ -395,7 +394,7 @@ ChapTrajectoryAnalysis::initOptions(
                                       "probability density of the solvent "
                                       "particles along the permeation "
                                       "pathway"));
-
+    
     options -> addOption(RealOption("de-res")
                          .store(&deResolution_)
                          .defaultValue(0.01)
@@ -435,7 +434,7 @@ ChapTrajectoryAnalysis::initOptions(
 
     // HYDROPHOBICITY PARAMETERS
     //-------------------------------------------------------------------------
-
+    
     const char * const allowedHydrophobicityDatabase[] = {"hessa_2005",
                                                           "kyte_doolittle_1982",
                                                           "monera_1995",
@@ -467,7 +466,7 @@ ChapTrajectoryAnalysis::initOptions(
                                       "hydrophobicity scale. Will be "
                                       "ignored unless -hydrophobicity-database"
                                       " is set to 'user'."));
-
+    
     options -> addOption(RealOption("hydrophob-bandwidth")
                          .store(&hpBandWidth_)
                          .defaultValue(0.35)
@@ -476,14 +475,13 @@ ChapTrajectoryAnalysis::initOptions(
 
 
 /*!
- *
+ * 
  */
 void
 ChapTrajectoryAnalysis::initAnalysis(
         const TrajectoryAnalysisSettings& /*settings*/,
         const TopologyInformation &top)
 {
-    std::cout << "ChapTrajectoryAnalysis::initAnalysis " << std::endl;
     // the following code ensures compatibility across Gromacs versions:
     // (there was an API break between 2016 and 2018)
     #if GROMACS_VERSION_MAJOR>=2018
@@ -504,7 +502,7 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // check validity of input parameters:
     checkParameters();
-
+        
     // save atom coordinates in topology for writing to output later:
     outputStructure_.fromTopology(top);
 
@@ -546,19 +544,19 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // prepare container for original path points:
     frameStreamData_.setColumnCount(1, 4);
-    frameStreamColumnNames.push_back({"x",
+    frameStreamColumnNames.push_back({"x", 
                                       "y",
                                       "z",
                                       "r"});
 
     // prepare container for path radius:
     frameStreamData_.setColumnCount(2, 2);
-    frameStreamColumnNames.push_back({"knots",
+    frameStreamColumnNames.push_back({"knots", 
                                       "ctrl"});
 
     // prepare container for pathway spline:
     frameStreamData_.setColumnCount(3, 4);
-    frameStreamColumnNames.push_back({"knots",
+    frameStreamColumnNames.push_back({"knots", 
                                       "ctrlX",
                                       "ctrlY",
                                       "ctrlZ"});
@@ -579,7 +577,7 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // prepare container for solvent mapping:
     frameStreamData_.setColumnCount(5, 9);
-    frameStreamColumnNames.push_back({"resId",
+    frameStreamColumnNames.push_back({"resId", 
                                       "s",
                                       "rho",
                                       "phi",
@@ -591,15 +589,15 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // prepare container for solvent density:
     frameStreamData_.setColumnCount(6, 2);
-    frameStreamColumnNames.push_back({"knots",
+    frameStreamColumnNames.push_back({"knots", 
                                       "ctrl"});
 
     // prepare container for hydrophobicity splines:
     frameStreamData_.setColumnCount(7, 2);
-    frameStreamColumnNames.push_back({"knots",
+    frameStreamColumnNames.push_back({"knots", 
                                       "ctrl"});
     frameStreamData_.setColumnCount(8, 2);
-    frameStreamColumnNames.push_back({"knots",
+    frameStreamColumnNames.push_back({"knots", 
                                       "ctrl"});
 
     // add JSON exporter to frame stream data:
@@ -617,7 +615,7 @@ ChapTrajectoryAnalysis::initAnalysis(
     // prepare a centre of geometry selection collection:
     poreMappingSelCol_.setReferencePosType("res_cog");
     poreMappingSelCol_.setOutputPosType("res_cog");
-
+  
     // selection of C-alpha atoms:
     std::string pathwaySelSelText = pathwaySel_.selectionText();
     std::string poreMappingSelCalString = pfSelString_;
@@ -625,19 +623,19 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // create index groups from topology:
     gmx_ana_indexgrps_t *poreIdxGroups;
-
+ 
     // has external index file been specified?
     if( customNdxFileName_.size() != 0 )
     {
-        gmx_ana_indexgrps_init(&poreIdxGroups,
-                               topologyPointer.get(),
-                               customNdxFileName_.c_str());
+        gmx_ana_indexgrps_init(&poreIdxGroups, 
+                               topologyPointer.get(), 
+                               customNdxFileName_.c_str());  
     }
     else
     {
-        gmx_ana_indexgrps_init(&poreIdxGroups,
-                               topologyPointer.get(),
-                               NULL);
+        gmx_ana_indexgrps_init(&poreIdxGroups, 
+                               topologyPointer.get(), 
+                               NULL); 
     }
 
     // create selections as defined above:
@@ -653,7 +651,7 @@ ChapTrajectoryAnalysis::initAnalysis(
     // do we have one C-alpha for each pore-forming residue?
     if( poreMappingSelCal_.posCount() != poreMappingSelCog_.posCount() )
     {
-        findPfResidues_ = false;
+        findPfResidues_ = false;  
     }
     else
     {
@@ -704,7 +702,7 @@ ChapTrajectoryAnalysis::initAnalysis(
         gmx_ana_indexgrps_free(solvIdxGroups);
     }
 
-
+    
     // GET ATOM RADII FROM TOPOLOGY
     //-------------------------------------------------------------------------
 
@@ -744,10 +742,10 @@ ChapTrajectoryAnalysis::initAnalysis(
         }
     }
 
-    // import vdW radii JSON:
+    // import vdW radii JSON: 
     JsonDocImporter jdi;
     rapidjson::Document radiiDoc = jdi(pfVdwRadiusJson_.c_str());
-
+   
     // create radius provider and build lookup table:
     VdwRadiusProvider vrp;
     vrp.lookupTableFromJson(radiiDoc);
@@ -763,7 +761,7 @@ ChapTrajectoryAnalysis::initAnalysis(
             pathwaySel_.mappedIds().data(),
             pathwaySel_.mappedIds().data() + pathwaySel_.mappedIds().size());
 
-
+    
 
     // build vdw radius lookup map:
     vdwRadii_ = vrp.vdwRadiiForTopology(top, mappedIds);
@@ -780,9 +778,9 @@ ChapTrajectoryAnalysis::initAnalysis(
     resInfo_.chainFromTopology(top);
 
     // base path to location of hydrophobicity databases:
-    std::string hydrophobicityFilePath = chapInstallBase() +
+    std::string hydrophobicityFilePath = chapInstallBase() + 
             std::string("/chap/share/data/hydrophobicity/");
-
+    
     // select appropriate database file:
     if( hydrophobicityDatabase_ == eHydrophobicityDatabaseHessa2005 )
     {
@@ -825,7 +823,7 @@ ChapTrajectoryAnalysis::initAnalysis(
 
     // import hydrophbicity JSON:
     rapidjson::Document hydrophobicityDoc = jdi(hydrophobicityJson_.c_str());
-
+   
     // generate hydrophobicity lookup table:
     resInfo_.hydrophobicityFromJson(hydrophobicityDoc);
 
@@ -848,7 +846,7 @@ ChapTrajectoryAnalysis::initAfterFirstFrame(
         const TrajectoryAnalysisSettings &settings,
         const t_trxframe &fr)
 {
-    std::cout << "ChapTrajectoryAnalysis::initAfterFirstFrame blank program... " << std::endl;
+
 }
 
 
@@ -857,12 +855,11 @@ ChapTrajectoryAnalysis::initAfterFirstFrame(
  */
 void
 ChapTrajectoryAnalysis::analyzeFrame(
-        int frnr,
-        const t_trxframe &fr,
+        int frnr, 
+        const t_trxframe &fr, 
         t_pbc *pbc,
         TrajectoryAnalysisModuleData *pdata)
 {
-    std::cout << "ChapTrajectoryAnalysis::analyzeFrame " << std::endl;
     // get thread-local selections:
     const Selection &refSelection = pdata -> parallelSelection(pathwaySel_);
 
@@ -878,30 +875,30 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // recalculate initial probe position based on reference group COG:
     if( pfInitProbePosIsSet_ == false )
-    {
+    {  
         // helper variable for conditional assignment of selection:
         Selection tmpsel;
-
+  
         // has a group for specifying initial probe position been set?
         if( ippSelIsSet_ == true )
         {
             // use explicitly given selection:
             tmpsel = ippSel_;
         }
-        else
+        else 
         {
             // default to overall group of pore forming particles:
             tmpsel = pathwaySel_;
         }
-
+     
         // load data into initial position selection:
         const gmx::Selection &initPosSelection = pdata -> parallelSelection(tmpsel);
-
+ 
         // initialse total mass and COM vector:
         real totalMass = 0.0;
         gmx::RVec centreOfMass(0.0, 0.0, 0.0);
-
-        // loop over all atoms:
+        
+        // loop over all atoms: 
         for(int i = 0; i < initPosSelection.atomCount(); i++)
         {
             // get i-th atom position:
@@ -919,7 +916,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
         // scale COM vector by total MASS:
         centreOfMass[XX] /= 1.0 * totalMass;
         centreOfMass[YY] /= 1.0 * totalMass;
-        centreOfMass[ZZ] /= 1.0 * totalMass;
+        centreOfMass[ZZ] /= 1.0 * totalMass; 
 
         // set initial probe position:
         pfInitProbePos_[XX] = centreOfMass[XX];
@@ -952,7 +949,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // vectors as RVec:
     RVec initProbePos(pfInitProbePos_[0], pfInitProbePos_[1], pfInitProbePos_[2]);
-    RVec chanDirVec(pfChanDirVec_[0], pfChanDirVec_[1], pfChanDirVec_[2]);
+    RVec chanDirVec(pfChanDirVec_[0], pfChanDirVec_[1], pfChanDirVec_[2]); 
 
     // create path finding module:
     std::unique_ptr<AbstractPathFinder> pfm;
@@ -964,10 +961,10 @@ ChapTrajectoryAnalysis::analyzeFrame(
                                                       chanDirVec,
                                                       pbc,
                                                       refSelection,
-                                                      selVdwRadii));
+                                                      selVdwRadii));        
     }
     else if( pfMethod_ == ePathFindingMethodNaiveCylindrical )
-    {
+    {        
         // create the naive cylindrical path finder:
         pfm.reset(new NaiveCylindricalPathFinder(pfPar_,
                                                  initProbePos,
@@ -992,7 +989,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
     clock_t tMolPath = std::clock();
     MolecularPath molPath = pfm -> getMolecularPath();
     tMolPath = (std::clock() - tMolPath)/CLOCKS_PER_SEC;
-
+    
     // which method do we use for path alignment?
     if( pfPathAlignmentMethod_ == ePathAlignmentMethodNone )
     {
@@ -1026,7 +1023,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // add radius spline knots and control points to frame stream dataset:
     dhFrameStream.selectDataSet(2);
-    std::vector<real> radiusKnots = molPath.poreRadiusUniqueKnots();
+    std::vector<real> radiusKnots = molPath.poreRadiusUniqueKnots();    
     std::vector<real> radiusCtrlPoints = molPath.poreRadiusCtrlPoints();
     for(size_t i = 0; i < radiusKnots.size(); i++)
     {
@@ -1034,10 +1031,10 @@ ChapTrajectoryAnalysis::analyzeFrame(
         dhFrameStream.setPoint(1, radiusCtrlPoints.at(i));
         dhFrameStream.finishPointSet();
     }
-
+    
     // add centre line spline knots and control points to frame stream dataset:
     dhFrameStream.selectDataSet(3);
-    std::vector<real> centreLineKnots = molPath.centreLineUniqueKnots();
+    std::vector<real> centreLineKnots = molPath.centreLineUniqueKnots();    
     std::vector<gmx::RVec> centreLineCtrlPoints = molPath.centreLineCtrlPoints();
     for(size_t i = 0; i < centreLineKnots.size(); i++)
     {
@@ -1051,12 +1048,12 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // MAP PORE PARTICLES ONTO PATHWAY
     //-------------------------------------------------------------------------
-
+ 
     // evaluate pore mapping selection for this frame:
     t_trxframe frame = fr;
     poreMappingSelCol_.evaluate(&frame, pbc);
-    const gmx::Selection poreMappingSelCal = pdata -> parallelSelection(poreMappingSelCal_);
-    const gmx::Selection poreMappingSelCog = pdata -> parallelSelection(poreMappingSelCog_);
+    const gmx::Selection poreMappingSelCal = pdata -> parallelSelection(poreMappingSelCal_);    
+    const gmx::Selection poreMappingSelCog = pdata -> parallelSelection(poreMappingSelCog_);    
 
 
     // map pore residue COG onto pathway:
@@ -1071,11 +1068,11 @@ ChapTrajectoryAnalysis::analyzeFrame(
             poreMappingSelCal);
     tMapResCal = (std::clock() - tMapResCal)/CLOCKS_PER_SEC;
 
-
+    
     // check if particles are pore-lining:
     clock_t tResPoreLining = std::clock();
     std::map<int, bool> poreLining = molPath.checkIfInside(
-            poreCogMappedCoords,
+            poreCogMappedCoords, 
             poreMappingMargin_);
     int nPoreLining = 0;
     for(auto jt = poreLining.begin(); jt != poreLining.end(); jt++)
@@ -1089,7 +1086,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // check if residues are pore-facing:
     // TODO: make this conditional on whether C-alphas are available
-
+    
     clock_t tResPoreFacing = std::clock();
     std::map<int, bool> poreFacing;
     int nPoreFacing = 0;
@@ -1105,15 +1102,15 @@ ChapTrajectoryAnalysis::analyzeFrame(
         }
         else
         {
-            poreFacing[it->first] = false;
+            poreFacing[it->first] = false;            
         }
     }
     tResPoreFacing = (std::clock() - tResPoreFacing)/CLOCKS_PER_SEC;
-
+    
 
     // ESTIMATE HYDROPHOBICITY PROFILE
     //-------------------------------------------------------------------------
-
+   
     // get vectors of coordinates of pore-facing and -lining residues:
     std::vector<real> plResidueCoordS;
     std::vector<real> plResidueHydrophobicity;
@@ -1164,36 +1161,36 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
     // estimate hydrophobicity profiles due to pore-lining residues:
     SplineCurve1D plHydrophobicity = kernelSmoother.estimate(
-            plResidueCoordS,
+            plResidueCoordS, 
             plResidueHydrophobicity);
 
-    // add spline curve parameters to data handle:
+    // add spline curve parameters to data handle:   
     dhFrameStream.selectDataSet(7);
     for(size_t i = 0; i < plHydrophobicity.ctrlPoints().size(); i++)
     {
         dhFrameStream.setPoint(
-                0,
+                0, 
                 plHydrophobicity.uniqueKnots().at(i));
         dhFrameStream.setPoint(
-                1,
+                1, 
                 plHydrophobicity.ctrlPoints().at(i));
         dhFrameStream.finishPointSet();
     }
 
     // estimate hydrophobicity profiles due to pore-facing residues:
     SplineCurve1D pfHydrophobicity = kernelSmoother.estimate(
-            pfResidueCoordS,
+            pfResidueCoordS, 
             pfResidueHydrophobicity);
 
-    // add spline curve parameters to data handle:
+    // add spline curve parameters to data handle:   
     dhFrameStream.selectDataSet(8);
     for(size_t i = 0; i < pfHydrophobicity.ctrlPoints().size(); i++)
     {
         dhFrameStream.setPoint(
-                0,
+                0, 
                 pfHydrophobicity.uniqueKnots().at(i));
         dhFrameStream.setPoint(
-                1,
+                1, 
                 pfHydrophobicity.ctrlPoints().at(i));
         dhFrameStream.finishPointSet();
     }
@@ -1203,7 +1200,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
     //-------------------------------------------------------------------------
 
     // create data containers:
-    std::map<int, gmx::RVec> solventMappedCoords;
+    std::map<int, gmx::RVec> solventMappedCoords; 
     std::map<int, bool> solvInsideSample;
     std::map<int, bool> solvInsidePore;
     int numSolvInsideSample = 0;
@@ -1218,7 +1215,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
         // TODO: make this a parameter:
         real solvMappingMargin_ = 0.0;
-
+            
         // get thread-local selection data:
         const Selection solvMapSel = pdata -> parallelSelection(solvMappingSelCog_);
 
@@ -1230,10 +1227,10 @@ ChapTrajectoryAnalysis::analyzeFrame(
         // find particles inside path (i.e. pore plus bulk sampling regime):
         clock_t tSolInsideSample = std::clock();
         solvInsideSample = molPath.checkIfInside(
-                solventMappedCoords,
+                solventMappedCoords, 
                 solvMappingMargin_);
         for(auto jt = solvInsideSample.begin(); jt != solvInsideSample.end(); jt++)
-        {
+        {            
             if( jt -> second == true )
             {
                 numSolvInsideSample++;
@@ -1244,12 +1241,12 @@ ChapTrajectoryAnalysis::analyzeFrame(
         // find particles inside pore:
         clock_t tSolInsidePore = std::clock();
         solvInsidePore = molPath.checkIfInside(
-                solventMappedCoords,
+                solventMappedCoords, 
                 solvMappingMargin_,
                 molPath.sLo(),
                 molPath.sHi());
         for(auto jt = solvInsidePore.begin(); jt != solvInsidePore.end(); jt++)
-        {
+        {            
             if( jt -> second == true )
             {
                 numSolvInsidePore++;
@@ -1259,16 +1256,16 @@ ChapTrajectoryAnalysis::analyzeFrame(
 
         // now add mapped residue coordinates to data handle:
         dhFrameStream.selectDataSet(5);
-
+        
         // add mapped residues to data container:
-        for(auto it = solventMappedCoords.begin();
-            it != solventMappedCoords.end();
+        for(auto it = solventMappedCoords.begin(); 
+            it != solventMappedCoords.end(); 
             it++)
         {
              dhFrameStream.setPoint(0, solvMapSel.position(it -> first).mappedId()); // res.id
              dhFrameStream.setPoint(1, it -> second[0]);     // s
              dhFrameStream.setPoint(2, it -> second[1]);     // rho
-             dhFrameStream.setPoint(3, 0.0);                 // phi
+             dhFrameStream.setPoint(3, 0.0);                 // phi 
              dhFrameStream.setPoint(4, solvInsidePore[it -> first]);        // inside pore
              dhFrameStream.setPoint(5, solvInsideSample[it -> first]);      // inside sample
              dhFrameStream.setPoint(6, solvMapSel.position(it -> first).x()[XX]);  // x
@@ -1278,7 +1275,7 @@ ChapTrajectoryAnalysis::analyzeFrame(
         }
     }
 
-
+    
     // ESTIMATE SOLVENT DENSITY
     //-------------------------------------------------------------------------
 
@@ -1334,15 +1331,15 @@ ChapTrajectoryAnalysis::analyzeFrame(
     SplineCurve1D solventDensityCoordS = densityEstimator -> estimate(
             solventSampleCoordS);
 
-    // add spline curve parameters to data handle:
+    // add spline curve parameters to data handle:   
     dhFrameStream.selectDataSet(6);
     for(size_t i = 0; i < solventDensityCoordS.ctrlPoints().size(); i++)
     {
         dhFrameStream.setPoint(
-                0,
+                0, 
                 solventDensityCoordS.uniqueKnots().at(i));
         dhFrameStream.setPoint(
-                1,
+                1, 
                 solventDensityCoordS.ctrlPoints().at(i));
         dhFrameStream.finishPointSet();
     }
@@ -1355,17 +1352,17 @@ ChapTrajectoryAnalysis::analyzeFrame(
     SplineCurve1D pathRadius = molPath.pathRadius();
     NumberDensityCalculator ncc;
     SplineCurve1D numberDensity = ncc(
-            solventDensityCoordS,
-            pathRadius,
+            solventDensityCoordS, 
+            pathRadius, 
             numSolvInsideSample);
-
+  
     // find minimum instantaneous solvent density in this frame:
     std::pair<real, real> lim(molPath.sLo(), molPath.sHi());
     std::pair<real, real> minSolventDensity = numberDensity.minimum(lim);
 
 
     // ADD AGGREGATE DATA TO PARALLELISABLE CONTAINER
-    //-------------------------------------------------------------------------
+    //-------------------------------------------------------------------------   
 
     // add aggegate path data:
     dhFrameStream.selectDataSet(0);
@@ -1376,13 +1373,13 @@ ChapTrajectoryAnalysis::analyzeFrame(
     dhFrameStream.setPoint(2, molPath.minRadius().second);
     dhFrameStream.setPoint(3, molPath.length());
     dhFrameStream.setPoint(4, molPath.volume());
-    dhFrameStream.setPoint(5, numSolvInsidePore);
-    dhFrameStream.setPoint(6, numSolvInsideSample);
-    dhFrameStream.setPoint(7, solventRangeLo);
+    dhFrameStream.setPoint(5, numSolvInsidePore); 
+    dhFrameStream.setPoint(6, numSolvInsideSample); 
+    dhFrameStream.setPoint(7, solventRangeLo); 
     dhFrameStream.setPoint(8, solventRangeHi);
-    dhFrameStream.setPoint(9, minSolventDensity.first);
+    dhFrameStream.setPoint(9, minSolventDensity.first); 
     dhFrameStream.setPoint(10, minSolventDensity.second);
-    dhFrameStream.setPoint(11, molPath.sLo());
+    dhFrameStream.setPoint(11, molPath.sLo()); 
     dhFrameStream.setPoint(12, molPath.sHi());
     dhFrameStream.setPoint(13, deParams_.bandWidth()*deParams_.bandWidthScale());
     dhFrameStream.finishPointSet();
@@ -1439,20 +1436,8 @@ ChapTrajectoryAnalysis::analyzeFrame(
 void
 ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 {
-    std::cout << "ChapTrajectoryAnalysis::finishAnalysis with argument numFrames " <<  numFrames << std::endl;
     // free line for neater output:
     std::cout<<std::endl;
-
-    // read in test file
-    std::fstream inFile2;
-    inFile2.open("test.txt", std::fstream::in);
-    std::cout << "inFile2.is_open() (test.txt) " << inFile2.is_open() << std::endl;
-    std::string line2;
-    while( std::getline(inFile2, line2) )
-    {
-      std::cout << "test while loop touched" << std::endl;
-      std::cout << line2 << std::endl;
-    }
 
     // transfer file names from user input:
     std::string inFileName = std::string("stream_") + outputJsonFileName_;
@@ -1465,30 +1450,6 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
     // openen per-frame data set for reading:
     inFile.open(inFileName, std::fstream::in);
-    std::cout << "inFileName " << inFileName << std::endl;
-    std::cout << "inFile.is_open() " << inFile.is_open() << std::endl;
-    std::ifstream f(inFileName);
-    if (inFile.is_open())
-    {
-        std::cout << "inFile IS open " << inFileName << std::endl;
-        // https://stackoverflow.com/questions/35201919/how-do-i-print-out-the-contents-of-a-file-c-file-stream
-        std::cout << "try f.rdbuf() " << std::endl;
-        //try {std::cout << f.rdbuf() << std::endl;}
-        //catch (const std::exception& e) {
-        //  std::cout << " a standard exception was caught, with message '"  << e.what() << std::endl;
-        //}
-        //catch (...) { std::cout << "f.rdbuf() not succesful" << std::endl; }
-
-        std::cout << "try inFile.rdbuf() " << std::endl;
-        //try {std::cout << inFile.rdbuf() << std::endl;}
-        //catch (const std::exception& e) {
-        //  std::cout << " a standard exception was caught, with message '"  << e.what() << std::endl;
-        //}
-        //catch (...) { std::cout << "inFile.rdbuf() not succesful" << std::endl; }
-    }
-    else {
-        std::cout << "inFile is NOT open " << inFileName << std::endl;
-    }
 
     // prepare summary statistics for aggregate properties:
     SummaryStatistics argMinRadiusSummary;
@@ -1526,14 +1487,8 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     // read file line by line and calculate summary statistics:
     int linesRead = 0;
     std::string line;
-    std::cout << "inFile.is_open() " << inFile.is_open() << std::endl;
-    std::cout << "std::getline(inFile, line) " << std::getline(inFile, line) << std::endl;
-    std::cout << "return value = input (the stream to get data from , here inFile) " << std::endl;
-    std::cout << "inFile " << inFile << " line " << line << std::endl;
-    std::cout << "inFile.is_open() " << inFile.is_open() << std::endl;
     while( std::getline(inFile, line) )
     {
-        std::cout << "while loop touched" << std::endl;
         // read line into JSON document:
         rapidjson::StringStream lineStream(line.c_str());
         rapidjson::Document lineDoc;
@@ -1543,11 +1498,11 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         if( !lineDoc.IsObject() )
         {
             // FIXME this is where the JSON error occurs
-            std::string error = "Line " + std::to_string(linesRead) +
+            std::string error = "Line " + std::to_string(linesRead) + 
             " read from" + inFileName + " is not valid JSON object.";
             throw std::runtime_error(error);
         }
-
+    
         // calculate summary statistics of aggregate variables:
         argMinRadiusSummary.update(
                 lineDoc["pathSummary"]["argMinRadius"][0].GetDouble());
@@ -1575,7 +1530,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
                 lineDoc["pathSummary"]["arcLengthHi"][0].GetDouble());
         bandWidthSummary.update(
                 lineDoc["pathSummary"]["bandWidth"][0].GetDouble());
-
+        
         // get time stamp of current frame:
         real timeStamp = lineDoc["pathSummary"]["timeStamp"][0].GetDouble();
         timeStamps.push_back(timeStamp);
@@ -1609,15 +1564,12 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
     // close per frame data set:
     inFile.close();
-
+    
     // sanity check:
     if( linesRead != numFrames )
     {
-        //throw std::runtime_error("Number of frames read does not equal number"
-        //"of frames analyised.");
-        std::cout << "Number of frames read does not equal number of frames analyised" <<std::endl;
-        std::cout << "linesRead " << linesRead <<std::endl;
-        std::cout << "numFrames " << numFrames <<std::endl;
+        throw std::runtime_error("Number of frames read does not equal number"
+        "of frames analyised.");
     }
 
 
@@ -1645,9 +1597,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
     // open JSON data file in read mode:
     inFile.open(inFileName.c_str(), std::fstream::in);
-    std::cout << " open JSON data file in read mode: inFileName.c_str() " << inFileName.c_str() <<std::endl;
-    std::cout << "inFile.is_open() " << inFile.is_open() << std::endl;
-
+    
     // prepare containers for profile summaries:
     std::vector<SummaryStatistics> radiusSummary(supportPoints.size());
     std::vector<SummaryStatistics> solventDensitySummary(supportPoints.size());
@@ -1667,7 +1617,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     std::vector<SummaryStatistics> residueYSummary(numPoreRes);
     std::vector<SummaryStatistics> residueZSummary(numPoreRes);
 
-    // containers for profile valued time series:
+    // containers for profile valued time series: 
     std::vector<std::vector<real>> radiusProfileTimeSeries;
     std::vector<std::vector<real>> solventDensityTimeSeries;
     std::vector<std::vector<real>> plHydrophobicityTimeSeries;
@@ -1675,7 +1625,6 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
     // read file line by line:
     int linesProcessed = 0;
-    std::cout << "std::getline(inFile, line) " << std::getline(inFile, line) << std::endl;
     while( std::getline(inFile, line) )
     {
         std::cout.precision(3);
@@ -1692,7 +1641,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         // sanity checks:
         if( !lineDoc.IsObject() )
         {
-            std::string error = "Line " + std::to_string(linesProcessed) +
+            std::string error = "Line " + std::to_string(linesProcessed) + 
             " read from" + inFileName + " is not valid JSON object.";
             throw std::runtime_error(error);
         }
@@ -1708,7 +1657,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         MolecularPath molPath(lineDoc);
 
         // sample radius at support points and add to summary statistics:
-        std::vector<real> radiusSample = molPath.sampleRadii(supportPoints);
+        std::vector<real> radiusSample = molPath.sampleRadii(supportPoints); 
         for(size_t i = 0; i < radiusSample.size(); i++)
         {
             radiusSummary.at(i).update(radiusSample.at(i));
@@ -1717,11 +1666,11 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         // add to time series:
         radiusProfileTimeSeries.push_back(radiusSample);
 
-
+        
         // sample points from hydrophobicity splines:
         SplineCurve1D pfHydrophobicitySpline = SplineCurve1DJsonConverter::fromJson(
                 lineDoc["pfHydrophobicitySpline"], 1);
-        std::vector<real> pfHydrophobicitySample =
+        std::vector<real> pfHydrophobicitySample = 
                 pfHydrophobicitySpline.evaluateMultiple(supportPoints, 0);
         SummaryStatistics::updateMultiple(
                 pfHydrophobicitySummary,
@@ -1730,7 +1679,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
         SplineCurve1D plHydrophobicitySpline = SplineCurve1DJsonConverter::fromJson(
                 lineDoc["plHydrophobicitySpline"], 1);
-        std::vector<real> plHydrophobicitySample =
+        std::vector<real> plHydrophobicitySample = 
                 plHydrophobicitySpline.evaluateMultiple(supportPoints, 0);
         SummaryStatistics::updateMultiple(
                 plHydrophobicitySummary,
@@ -1741,7 +1690,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         // sample points from solvent density spline:
         SplineCurve1D solventDensitySpline = SplineCurve1DJsonConverter::fromJson(
                 lineDoc["solventDensitySpline"], 1);
-        std::vector<real> solventDensitySample =
+        std::vector<real> solventDensitySample = 
                 solventDensitySpline.evaluateMultiple(supportPoints, 0);
 
         // get total number of particles in sample for this time step:
@@ -1751,14 +1700,14 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         // TODO this should be done in per-frame analysis:
         NumberDensityCalculator ndc;
         solventDensitySample = ndc(
-                solventDensitySample,
-                radiusSample,
+                solventDensitySample, 
+                radiusSample, 
                 totalNumber);
         SummaryStatistics::updateMultiple(
                 solventDensitySummary,
                 solventDensitySample);
         solventDensityTimeSeries.push_back(solventDensitySample);
-
+ 
         // convert to energy and add to summary statistic:
         BoltzmannEnergyCalculator bec;
         std::vector<real> energySample = bec.calculate(solventDensitySample);
@@ -1811,12 +1760,12 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
         // increment line counter:
         linesProcessed++;
     }
-
+  
     // shift of energy profile so that energy at anchor points is zero:
     real shift = -0.5*(anchorEnergyLo.mean() + anchorEnergyHi.mean());
     std::for_each(
-            energySummary.begin(),
-            energySummary.end(),
+            energySummary.begin(), 
+            energySummary.end(), 
             [this, shift](SummaryStatistics &s){s.shift(shift);});
 
     // inform user about progress:
@@ -1830,17 +1779,14 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     if( linesProcessed != numFrames )
     {
         std::string error = "Number of lines read from JSON file does not"
-        "equal number of frames processed!";
-        std::cout << "Number of lines read from JSON file does not equal number of frames processed!"  << std::endl;
-        std::cout << "linesProcessed " << linesProcessed  << std::endl;
-        std::cout << "numFrames " << numFrames  << std::endl;
-        // throw std::runtime_error(error);
+        "equal number of frames processed!"; 
+        throw std::runtime_error(error);
     }
 
     // close filestream object:
     inFile.close();
 
-
+    
     // CREATE PDB OUTPUT
     // ------------------------------------------------------------------------
 
@@ -1875,7 +1821,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     results.addPathwayProfile("pfHydrophobicity", pfHydrophobicitySummary);
     results.addPathwayProfile("density", solventDensitySummary);
     results.addPathwayProfile("energy", energySummary);
-
+    
     // add scalar time series data to output:
     results.addTimeStamps(timeStamps);
     results.addPathwayScalarTimeSeries("argMinRadius", argMinRadiusTimeSeries);
@@ -1915,7 +1861,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 
     // DELETE PER FRAME DATA
     // ------------------------------------------------------------------------
-
+   
     // detailed output requested?
     if( !outputDetailed_ )
     {
@@ -1944,24 +1890,24 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     // averaged properties as spline curves:
     CubicSplineInterp1D interp;
     auto avgRadiusSpl = interp(
-            supportPoints,
-            avgRadius,
+            supportPoints, 
+            avgRadius, 
             eSplineInterpBoundaryHermite);
     auto avgSolventDensitySpl = interp(
-            supportPoints,
-            avgSolventDensity,
+            supportPoints, 
+            avgSolventDensity, 
             eSplineInterpBoundaryHermite);
     auto avgEnergySpl = interp(
-            supportPoints,
-            avgEnergy,
+            supportPoints, 
+            avgEnergy, 
             eSplineInterpBoundaryHermite);
     auto avgPlHydrophobicitySpl = interp(
-            supportPoints,
-            avgPlHydrophobicity,
+            supportPoints, 
+            avgPlHydrophobicity, 
             eSplineInterpBoundaryHermite);
     auto avgPfHydrophobicitySpl = interp(
-            supportPoints,
-            avgPfHydrophobicity,
+            supportPoints, 
+            avgPfHydrophobicity, 
             eSplineInterpBoundaryHermite);
 
 
@@ -1974,7 +1920,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     molPathAvg_ -> addScalarProperty("avg_pf_hydrophobicity", avgPfHydrophobicitySpl, true);
 
     // load colour palettes from JSON file:
-    std::string paletteFilePath = chapInstallBase() +
+    std::string paletteFilePath = chapInstallBase() + 
             std::string("/chap/share/data/palettes/");
     std::string paletteFileName = paletteFilePath + "default.json";
     auto palettes = ColourPaletteProvider::fromJsonFile(paletteFileName);
@@ -1985,8 +1931,8 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     mpexp.setGridSampleDist(outputGridSampleDist_);
     mpexp.setCorrectionThreshold(outputCorrectionThreshold_);
     mpexp(
-        outputBaseFileName_,
-        "time_averaged_molecular_path",
+        outputBaseFileName_, 
+        "time_averaged_molecular_path", 
         *molPathAvg_,
         palettes);
 }
@@ -1998,7 +1944,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
 void
 ChapTrajectoryAnalysis::writeOutput()
 {
-    std::cout << "ChapTrajectoryAnalysis::writeOutput blank..." << std::endl;
+
 }
 
 
@@ -2010,7 +1956,6 @@ ChapTrajectoryAnalysis::writeOutput()
 void
 ChapTrajectoryAnalysis::obtainNdxFilePathInfo()
 {
-    std::cout << "ChapTrajectoryAnalysis::obtainNdxFilePathInfo " << std::endl;
     // name of index file flag:
     std::string flagName = " -n ";
 
@@ -2033,21 +1978,19 @@ ChapTrajectoryAnalysis::obtainNdxFilePathInfo()
 }
 
 
-/*!
- * Auxiliary function for checking the validity of various input parameters.
+/*! 
+ * Auxiliary function for checking the validity of various input parameters. 
  * Bundled here to keep initAnalysis() uncluttered.
  */
 void
 ChapTrajectoryAnalysis::checkParameters()
 {
-    std::cout << "ChapTrajectoryAnalysis::checkParameters " << std::endl;
     // OUTPUT PARAMETERS
     //-------------------------------------------------------------------------
 
     // add proper extensions to file names:
     // TODO: better in exporter code?
     outputJsonFileName_ = outputBaseFileName_ + ".json";
-    std::cout << "outputJsonFileName_ " << outputJsonFileName_ << std::endl;
     outputPdbFileName_ = outputBaseFileName_ + ".pdb";
 
     // sanity checks:
@@ -2061,7 +2004,7 @@ ChapTrajectoryAnalysis::checkParameters()
         throw std::runtime_error("Parameter -out-grid-dist must be strictly "
                                  "positive.");
     }
-    if( outputCorrectionThreshold_ >= 1.0 or
+    if( outputCorrectionThreshold_ >= 1.0 or 
         outputCorrectionThreshold_ <= -1.0)
     {
         throw std::runtime_error("Parameter -out-vis-teak must be in interval "
@@ -2096,7 +2039,7 @@ ChapTrajectoryAnalysis::checkParameters()
     pfParams_.setProbeStepLength(pfProbeStepLength_);
     pfParams_.setMaxProbeRadius(pfMaxProbeRadius_);
     pfParams_.setMaxProbeSteps(pfMaxProbeSteps_);
-
+    
     if( cutoffIsSet_ )
     {
         // this will be determined automatically if not set explcitly:
@@ -2121,7 +2064,7 @@ ChapTrajectoryAnalysis::checkParameters()
         deParams_.setMaxEvalPointDist(deResolution_);
     }
 
-
+    
     // HYDROPHOBICITY PARAMETERS
     //-------------------------------------------------------------------------
 
@@ -2133,3 +2076,4 @@ ChapTrajectoryAnalysis::checkParameters()
     hydrophobKernelParams_.setEvalRangeCutoff(hpEvalRangeCutoff_);
     hydrophobKernelParams_.setMaxEvalPointDist(hpResolution_);
 }
+

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1443,6 +1443,16 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     // free line for neater output:
     std::cout<<std::endl;
 
+    // read in tst file
+    inFile.open("test.txt", std::fstream::in);
+    std::cout << "inFileName test.txt " << inFileName << std::endl;
+    std::string line;
+    while( std::getline(inFile, line) )
+    {
+      std::cout << "test while loop touched" << std::endl;
+      std::cout << line << std::endl;
+    }
+
     // transfer file names from user input:
     std::string inFileName = std::string("stream_") + outputJsonFileName_;
     std::string outFileName = outputJsonFileName_;

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1455,6 +1455,7 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     // openen per-frame data set for reading:
     inFile.open(inFileName, std::fstream::in);
     std::cout << "inFileName " << inFileName << std::endl;
+    std::cout << "inFile.is_open() " << inFile.is_open() << std::endl;
 
     // prepare summary statistics for aggregate properties:
     SummaryStatistics argMinRadiusSummary;

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1444,14 +1444,14 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     std::cout<<std::endl;
 
     // read in test file
-    std::fstream inFile;
-    inFile.open("test.txt", std::fstream::in);
-    std::cout << "inFile.is_open() (test.txt) " << inFile.is_open() << std::endl;
-    std::string line;
-    while( std::getline(inFile, line) )
+    std::fstream inFile2;
+    inFile2.open("test.txt", std::fstream::in);
+    std::cout << "inFile2.is_open() (test.txt) " << inFile2.is_open() << std::endl;
+    std::string line2;
+    while( std::getline(inFile2, line2) )
     {
       std::cout << "test while loop touched" << std::endl;
-      std::cout << line << std::endl;
+      std::cout << line2 << std::endl;
     }
 
     // transfer file names from user input:

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1443,10 +1443,10 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     // free line for neater output:
     std::cout<<std::endl;
 
-    // read in tst file
+    // read in test file
     std::fstream inFile;
     inFile.open("test.txt", std::fstream::in);
-    std::cout << "inFileName test.txt " << inFileName << std::endl;
+    std::cout << "inFile.is_open() (test.txt) " << inFile.is_open() << std::endl;
     std::string line;
     while( std::getline(inFile, line) )
     {

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1456,9 +1456,19 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     inFile.open(inFileName, std::fstream::in);
     std::cout << "inFileName " << inFileName << std::endl;
     std::cout << "inFile.is_open() " << inFile.is_open() << std::endl;
+    std::ifstream f(inFileName);
     if (inFile.is_open())
+    {
         std::cout << "print " << inFileName << std::endl;
+        // https://stackoverflow.com/questions/35201919/how-do-i-print-out-the-contents-of-a-file-c-file-stream
+        std::cout << "f.rdbuf() " << std::endl;
+        std::cout << f.rdbuf() << std::endl;
+        std::cout << "inFile.rdbuf() "  << std::endl;
         std::cout << inFile.rdbuf() << std::endl;
+    }
+    else {
+        std::cout << "inFile is NOT open " << inFileName << std::endl;
+    }
 
     // prepare summary statistics for aggregate properties:
     SummaryStatistics argMinRadiusSummary;

--- a/src/trajectory-analysis/chap_trajectory_analysis.cpp
+++ b/src/trajectory-analysis/chap_trajectory_analysis.cpp
@@ -1456,6 +1456,9 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     inFile.open(inFileName, std::fstream::in);
     std::cout << "inFileName " << inFileName << std::endl;
     std::cout << "inFile.is_open() " << inFile.is_open() << std::endl;
+    if (inFile.is_open())
+        std::cout << "print " << inFileName << std::endl;
+        std::cout << inFile.rdbuf();
 
     // prepare summary statistics for aggregate properties:
     SummaryStatistics argMinRadiusSummary;
@@ -1493,9 +1496,11 @@ ChapTrajectoryAnalysis::finishAnalysis(int numFrames)
     // read file line by line and calculate summary statistics:
     int linesRead = 0;
     std::string line;
+    std::cout << "inFile.is_open() " << inFile.is_open() << std::endl;
     std::cout << "std::getline(inFile, line) " << std::getline(inFile, line) << std::endl;
     std::cout << "return value = input (the stream to get data from , here inFile) " << std::endl;
     std::cout << "inFile " << inFile << " line " << line << std::endl;
+    std::cout << "inFile.is_open() " << inFile.is_open() << std::endl;
     while( std::getline(inFile, line) )
     {
         std::cout << "while loop touched" << std::endl;


### PR DESCRIPTION
I committed a python3 compatible version of wobj.py (called wobj_python3.py).
I replaced every `map()` with `list(map())` in the wobj.py script because In Python 3, " map" returns an iterable object of type map, and not a subscriptible list.
This should fix issue #12.